### PR TITLE
DQSAAS-826 Fix status and check commit if already in dest branch

### DIFF
--- a/flow-manager/manager.go
+++ b/flow-manager/manager.go
@@ -1,6 +1,8 @@
 package flow_manager
 
 import (
+	"fmt"
+
 	"github.com/Docplanner/github-flow-manager/github"
 	"github.com/araddon/qlbridge/datasource"
 	"github.com/araddon/qlbridge/expr"
@@ -17,9 +19,20 @@ func Manage(githubToken, owner, repo, sourceBranch, destinationBranch, expressio
 	}
 	firstParentCommits := github.PickFirstParentCommits(commits)
 
+	destinationCommits, err := gm.GetCommits(owner, repo, destinationBranch, 1)
+	if nil != err {
+		return nil, err
+	}
+
 	var evaluationResultList []evaluationResult
 	builtins.LoadAllBuiltins()
 	for _, commit := range firstParentCommits {
+
+		if destinationCommits[0].SHA == commit.SHA {
+			fmt.Println("COMMIT ID: " + commit.SHA + " IS ALREADY IN " + destinationBranch + " branch. EXITING THE PROCESS WITHOUT ANY ACTION.")
+			return evaluationResultList, nil
+		}
+
 		evalContext := datasource.NewContextSimpleNative(map[string]interface{}{
 			"SHA":           commit.SHA,
 			"Message":       commit.Message,

--- a/github/github-query.go
+++ b/github/github-query.go
@@ -18,12 +18,14 @@ type githubQuery struct {
 										}
 									}
 								} `graphql:"parents(first: $parentsNumber)"`
-								Oid        githubql.String
-								Message    githubql.String
-								PushedDate githubql.DateTime
-								Status struct {
-									Id    githubql.String
-									State githubql.String
+								Oid               githubql.String
+								Message           githubql.String
+								PushedDate        githubql.DateTime
+								StatusCheckRollup struct {
+									State    githubql.String
+									Contexts struct {
+										TotalCount githubql.Int
+									} `graphql:"contexts(first: $parentsNumber)"`
 								}
 							}
 						}


### PR DESCRIPTION
1. First issue
Currently we read from Status field and looks like now this field gets with empty value. We will read the value from StatusCheckRollup instead

![image](https://user-images.githubusercontent.com/6449134/107215014-0b32df80-6a0b-11eb-8f44-0119a354e1b2.png)

2. Second issue
Currently we check all commits even thought the commit is already in the destination branch, so we get an error. We added a check to see if dest branch already contains that commit and so it log it and exit 