### PR TITLE
DQSAAS-862 add a new input parameter to check the commit status based on a specific commit check

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,12 +4,11 @@ import (
 	"fmt"
 	"os"
 
-	"strings"
-	"time"
-
-	flow_manager "github.com/Docplanner/github-flow-manager/flow-manager"
+	"github.com/Docplanner/github-flow-manager/flow-manager"
 	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
+	"strings"
+	"time"
 )
 
 var commitsNumber *int

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,11 +4,12 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/Docplanner/github-flow-manager/flow-manager"
-	"github.com/olekukonko/tablewriter"
-	"github.com/spf13/cobra"
 	"strings"
 	"time"
+
+	flow_manager "github.com/Docplanner/github-flow-manager/flow-manager"
+	"github.com/olekukonko/tablewriter"
+	"github.com/spf13/cobra"
 )
 
 var commitsNumber *int
@@ -22,17 +23,19 @@ const SYMBOL_FAIL = "✖"
 
 var rootCmd = &cobra.Command{
 	Args:  cobra.MinimumNArgs(5),
-	Use:   "github-flow-manager [OWNER] [REPOSITORY] [SOURCE_BRANCH] [DESTINATION_BRANCH] [EXPRESSION]",
+	Use:   "github-flow-manager [OWNER] [REPOSITORY] [SOURCE_BRANCH] [DESTINATION_BRANCH] [EXPRESSION] [SPECIFIC_COMMIT_CHECK_NAME]",
 	Short: "GitHub Flow Manager",
 	Long: `Main goal for that app is to push commits between branches
 but just those which pass evaluation checks. 
-Example use case "push all commits pushed to branch develop more than 30 minutes ago to branch master"`,
+Example use case "push all commits pushed to branch develop more than 30 minutes ago to branch master"
+If a SPECIFIC_COMMIT_CHECK_NAME is specified, the StatusSuccess will be calculated based ONLY on the result of that specific commit check`,
 	Run: func(cmd *cobra.Command, args []string) {
 		owner := args[0]
 		repo := args[1]
 		sourceBranch := args[2]
-		destinationBrnach := args[3]
+		destinationBranch := args[3]
 		expression := strings.Join(args[4:], " ")
+		specificCheckName := args[5]
 
 		for _, a := range args {
 			if len(a) < 1 {
@@ -50,7 +53,7 @@ Example use case "push all commits pushed to branch develop more than 30 minutes
 			}
 		}
 
-		results, err := flow_manager.Manage(*githubToken, owner, repo, sourceBranch, destinationBrnach, expression, *commitsNumber, *force, *dryRun)
+		results, err := flow_manager.Manage(*githubToken, owner, repo, sourceBranch, destinationBranch, expression, specificCheckName, *commitsNumber, *force, *dryRun)
 		if nil != err {
 			fmt.Println(err.Error())
 			os.Exit(1)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -35,7 +35,10 @@ If a SPECIFIC_COMMIT_CHECK_NAME is specified, the StatusSuccess will be calculat
 		sourceBranch := args[2]
 		destinationBranch := args[3]
 		expression := strings.Join(args[4:], " ")
-		specificCheckName := args[5]
+		specificCheckName := ""
+		if len(args) > 5 {
+			specificCheckName = args[5]
+		}
 
 		for _, a := range args {
 			if len(a) < 1 {

--- a/flow-manager/manager.go
+++ b/flow-manager/manager.go
@@ -10,16 +10,16 @@ import (
 	"github.com/araddon/qlbridge/vm"
 )
 
-func Manage(githubToken, owner, repo, sourceBranch, destinationBranch, expression string, lastCommitsNumber int, force, dryRun bool) ([]evaluationResult, error) {
+func Manage(githubToken, owner, repo, sourceBranch, destinationBranch, expression string, specificCheckName string, lastCommitsNumber int, force, dryRun bool) ([]evaluationResult, error) {
 	parsedExpression := expr.MustParse(expression)
 	gm := github.New(githubToken)
-	commits, err := gm.GetCommits(owner, repo, sourceBranch, lastCommitsNumber)
+	commits, err := gm.GetCommits(owner, repo, sourceBranch, lastCommitsNumber, specificCheckName)
 	if nil != err {
 		return nil, err
 	}
 	firstParentCommits := github.PickFirstParentCommits(commits)
 
-	destinationCommits, err := gm.GetCommits(owner, repo, destinationBranch, 1)
+	destinationCommits, err := gm.GetCommits(owner, repo, destinationBranch, 1, specificCheckName)
 	if nil != err {
 		return nil, err
 	}

--- a/github/commit.go
+++ b/github/commit.go
@@ -3,9 +3,10 @@ package github
 import "time"
 
 type Commit struct {
-	SHA           string
-	Message       string
-	Parents       []Commit
-	StatusSuccess bool
-	PushedDate    time.Time
+	SHA                 string
+	Message             string
+	Parents             []Commit
+	StatusSuccess       bool
+	PushedDate          time.Time
+	SpecificCheckPassed bool
 }

--- a/github/github-query.go
+++ b/github/github-query.go
@@ -27,6 +27,18 @@ type githubQuery struct {
 										TotalCount githubql.Int
 									} `graphql:"contexts(first: $parentsNumber)"`
 								}
+								CheckSuites struct {
+									Nodes []struct {
+										CheckRuns struct {
+											Nodes []struct {
+												Name       githubql.String
+												Status     githubql.String
+												Title      githubql.String
+												Conclusion githubql.String
+											}
+										} `graphql:"checkRuns(first: 100)"`
+									}
+								} `graphql:"checkSuites(first: 10)"`
 							}
 						}
 					} `graphql:"history(first: $commitsNumber)"`

--- a/github/manager.go
+++ b/github/manager.go
@@ -26,7 +26,7 @@ func New(githubAccessToken string) *githubManager {
 	return &githubManager{Context: ctx, Client: client, HttpClient: httpClient}
 }
 
-func (gm *githubManager) GetCommits(owner, repo, branch string, lastCommitsNumber int) ([]Commit, error) {
+func (gm *githubManager) GetCommits(owner, repo, branch string, lastCommitsNumber int, specificCheckName string) ([]Commit, error) {
 	if lastCommitsNumber > 100 || lastCommitsNumber < 1 {
 		return nil, &Error{Message: "lastCommitsNumber must be a number between 1 and 100"} // TODO maybe in future implement pagination
 	}
@@ -45,7 +45,7 @@ func (gm *githubManager) GetCommits(owner, repo, branch string, lastCommitsNumbe
 		return nil, err
 	}
 
-	return hydrateCommits(q), nil
+	return hydrateCommits(q, specificCheckName), nil
 }
 
 func PickFirstParentCommits(fullCommitsList []Commit) []Commit {
@@ -96,7 +96,7 @@ func (gm *githubManager) ChangeBranchHead(owner, repo, branch, sha string, force
 	return nil
 }
 
-func hydrateCommits(q *githubQuery) []Commit {
+func hydrateCommits(q *githubQuery, specificCheckName string) []Commit {
 	var fullCommitsList []Commit
 	for _, edge := range q.Repository.Ref.Target.Commit.History.Edges {
 		var parents []Commit
@@ -107,11 +107,25 @@ func hydrateCommits(q *githubQuery) []Commit {
 			})
 		}
 
+		statusSuccess := bool(edge.Node.StatusCheckRollup.State == githubql.String(githubql.StatusStateSuccess))
+
+		// In case a commit check name is specified, it override and get priority over the commit cumulative status
+		if specificCheckName != "" {
+			statusSuccess = false
+			for _, checkSuite := range edge.Node.CheckSuites.Nodes {
+				for _, checkRuns := range checkSuite.CheckRuns.Nodes {
+					if githubql.String(specificCheckName) == checkRuns.Name {
+						statusSuccess = checkRuns.Conclusion == githubql.String(githubql.StatusStateSuccess)
+					}
+				}
+			}
+		}
+
 		fullCommitsList = append(fullCommitsList, Commit{
 			SHA:           string(edge.Node.Oid),
 			Message:       string(edge.Node.Message),
 			Parents:       parents,
-			StatusSuccess: bool(edge.Node.StatusCheckRollup.State == githubql.String(githubql.StatusStateSuccess)),
+			StatusSuccess: statusSuccess,
 			PushedDate:    edge.Node.PushedDate.Time,
 		})
 	}

--- a/github/manager.go
+++ b/github/manager.go
@@ -107,11 +107,9 @@ func hydrateCommits(q *githubQuery, specificCheckName string) []Commit {
 			})
 		}
 
-		statusSuccess := bool(edge.Node.StatusCheckRollup.State == githubql.String(githubql.StatusStateSuccess))
-
+		statusSuccess := false
 		// In case a commit check name is specified, it override and get priority over the commit cumulative status
 		if specificCheckName != "" {
-			statusSuccess = false
 			for _, checkSuite := range edge.Node.CheckSuites.Nodes {
 				for _, checkRuns := range checkSuite.CheckRuns.Nodes {
 					if githubql.String(specificCheckName) == checkRuns.Name {
@@ -119,6 +117,8 @@ func hydrateCommits(q *githubQuery, specificCheckName string) []Commit {
 					}
 				}
 			}
+		} else {
+			statusSuccess = bool(edge.Node.StatusCheckRollup.State == githubql.String(githubql.StatusStateSuccess))
 		}
 
 		fullCommitsList = append(fullCommitsList, Commit{


### PR DESCRIPTION
Add to the script a new input parameter SPECIFIC_COMMIT_CHECK_NAME (optional) which is needed to define the StatusSuccess based on the status of a specific commit check (at this moment the commit checks we need to evaluate our pipelines linked to the commit). 
If the parameter is empty, the StatusSuccess will take the cumulative commit status

Why we need it?
Many times the cumulative commit status (based on the success of all checks connected to the commit) have misleading or wrong value, because:
- sometimes there are pipelines executed manually which can fail or canceled by the developer, so this will lead to a Pending/Failed cumulative status and this is a false negative
- there are "not Required" pipelines executed which can fail and we do not care, and this will also lead to a Failed cumulative status and this is a false negative

Example of usage, you have 2 options:
- passing new parameter
docker run docplanner/github-flow-manager:1.0.3 DocPlanner one-app develop master "StatusSuccess == true" "name-of-specific-pipeline-to-check" -v -t "token1234"
- NOT passing new parameter
docker run docplanner/github-flow-manager:1.0.3 DocPlanner one-app develop master "StatusSuccess == true" -v -t "token1234"