### PR TITLE
fix: add experimental docker-cli option for publish

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,6 +8,8 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    env:
+      DOCKER_CLI_EXPERIMENTAL: "enabled"
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
We need to set `DOCKER_CLI_EXPERIMENTAL=enabled` for the docker manifest command to work