### PR TITLE
Remove requiment for `ActionApp` retreival to workaround GH GraphQL issue

### DIFF
--- a/github/manager.go
+++ b/github/manager.go
@@ -104,18 +104,17 @@ func (gm *Manager) ChangeBranchHead(owner, repo, branch, sha string, force bool)
 
 func checkRunSet(cc int, cn string, edge Edge) int {
 	for _, checkSuite := range edge.Node.CheckSuites.Nodes {
-		if checkSuite.App.Name == "GitHub Actions" {
-			if githubv4.String(cn) == checkSuite.WorkflowRun.Workflow.Name {
-				if checkSuite.WorkflowRun.CheckSuite.Conclusion == githubv4.String(githubv4.StatusStateSuccess) {
-					cc++
-				}
+		if (checkSuite.WorkflowRun != WorkflowRun{}) && githubv4.String(cn) == checkSuite.WorkflowRun.Workflow.Name {
+			if checkSuite.WorkflowRun.CheckSuite.Conclusion == githubv4.String(githubv4.StatusStateSuccess) {
+				cc++
+				continue
 			}
-		} else {
-			for _, checkRuns := range checkSuite.CheckRuns.Nodes {
-				if githubv4.String(cn) == checkRuns.Name {
-					if checkRuns.Conclusion == githubv4.String(githubv4.StatusStateSuccess) {
-						cc++
-					}
+		}
+
+		for _, checkRuns := range checkSuite.CheckRuns.Nodes {
+			if githubv4.String(cn) == checkRuns.Name {
+				if checkRuns.Conclusion == githubv4.String(githubv4.StatusStateSuccess) {
+					cc++
 				}
 			}
 		}

--- a/github/types.go
+++ b/github/types.go
@@ -31,14 +31,8 @@ type WorkflowRun struct {
 	CheckSuite CheckSuite
 }
 
-// ActionApp represents the information about the Github Action App
-type ActionApp struct {
-	Name githubv4.String
-}
-
 // CheckSuiteNode represents the information about the check suite information of the Node
 type CheckSuiteNode struct {
-	App         ActionApp
 	WorkflowRun WorkflowRun
 	CheckRuns   CheckRuns `graphql:"checkRuns(first: 25)"`
 }


### PR DESCRIPTION
This PR proposes a possible solution to avoid permission issues using the new version of Github Flow Manager with GH Actions (eg. [this](https://github.com/DocPlanner/tmpargoxoan/runs/5556651475?check_suite_focus=true)).
This fix removes the retrieval of checkSuite App Name from the GraphQL query during the to-promote commit gathering.


The fix has been tested both with the new way (tests based on GH actions an thus leveraging the Workflows CheckSuites) and old way (on monolith-app & one-app)

The issue reside in a missing permission grant for Github Actions tokens to read org application installations, the same limitation is present in the tokens generated through custom Github Apps
This issue has been found in the wild [with some reports dating back to 2019](https://github.community/t/forbidden-for-checksuite-app-in-graphql-api/13975)