### PR TITLE
chore: increase the check suites to check

### DIFF
--- a/github/types.go
+++ b/github/types.go
@@ -87,7 +87,7 @@ type EdgeRootNode struct {
 	Message           githubv4.String
 	PushedDate        githubv4.DateTime
 	StatusCheckRollup StatusCheckRollup
-	CheckSuites       CheckSuites `graphql:"checkSuites(first: 10)"`
+	CheckSuites       CheckSuites `graphql:"checkSuites(first: 20)"`
 	Status            NodeStatus
 }
 


### PR DESCRIPTION
## Description
When the commit has a lot of check suites we are not able to get all of them with a limit of 10 so the checks fail. 