### PR TITLE
ci: bump actions/setup-go to v6.4.0 (SHA-pinned)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,7 @@ jobs:
         run: git fetch --prune --unshallow
 
       - name: Set up Go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: 1.16.x
 


### PR DESCRIPTION
## Summary

The `release-build` workflow has been failing on every tag push (see [run 26092694953](https://github.com/DocPlanner/github-flow-manager/actions/runs/26092694953/job/76722823337)). With debug logs enabled, the cause is visible:

```
Downloading Go from: https://storage.googleapis.com/golang/go1.16.15.linux-amd64.tar.gz
Failed to download from "https://storage.googleapis.com/golang/go1.16.15.linux-amd64.tar.gz". Code(403) Message(Forbidden)
```

`actions/setup-go@v1` hardcodes the legacy GCS bucket URL, which no longer serves Go 1.16 archives. Without debug logs the step exits silently with code 1 after ~3 minutes.

`actions/setup-go@v6.4.0` fetches from `go.dev/dl/` and the `actions/go-versions` releases mirror, where 1.16.15 is still available. SHA-pinned for supply-chain safety, tag in trailing comment.

This unblocks v1.1.9 — once merged, retag and the release should publish the new image.

## Test plan

- [ ] Merge, delete & repush tag `v1.1.9`
- [ ] Confirm release workflow completes and `ghcr.io/docplanner/github-flow-manager:1.1.9` + `:latest` are published

🤖 Generated with [Claude Code](https://claude.com/claude-code)