### PR TITLE
revert: roll checkSuites/checkRuns page sizes back to PR-#33 originals

### DIFF
--- a/github/types.go
+++ b/github/types.go
@@ -34,7 +34,7 @@ type WorkflowRun struct {
 // CheckSuiteNode represents the information about the check suite information of the Node
 type CheckSuiteNode struct {
 	WorkflowRun WorkflowRun
-	CheckRuns   CheckRuns `graphql:"checkRuns(first: 100)"`
+	CheckRuns   CheckRuns `graphql:"checkRuns(first: 25)"`
 }
 
 // CheckSuites represents the information about the check suite of a slice of Nodes

--- a/github/types.go
+++ b/github/types.go
@@ -93,7 +93,7 @@ type EdgeRootNode struct {
 	AuthoredDate      githubv4.DateTime
 	Author            Author
 	StatusCheckRollup StatusCheckRollup
-	CheckSuites       CheckSuites `graphql:"checkSuites(first: 100)"`
+	CheckSuites       CheckSuites `graphql:"checkSuites(first: 20)"`
 	Status            NodeStatus
 }
 


### PR DESCRIPTION
## Summary

Fully reverts the GraphQL query expansion from PR #33. Restores:

- `checkSuites(first: 100)` → `20`
- `checkRuns(first: 100)` → `25`

### Why

PR #33's bump inflates GraphQL cost ~20×: the nested `checkSuites × checkRuns` multiplier went from `20 × 25 = 500` to `100 × 100 = 10,000` per commit, pushing one GFM call from ~131 to ~2,526 points against the 5,000/hour bucket.

### Known consequence

Repos whose CI emits more than 25 check runs in a single suite — including DocPlanner/noa-whisper-app — will go back to evaluating as `IS STATUS SUCCESS: ✖` once `:latest` rolls forward. A follow-up that paginates `checkRuns` would fix both repos cleanly without the cost penalty.

## Test plan

- [x] `go build ./...` passes
- [ ] Merge, tag `v1.1.10`, confirm release workflow publishes the new image

🤖 Generated with [Claude Code](https://claude.com/claude-code)