### PR TITLE
fix: require every named check to pass, not a matching count

### DIFF
--- a/.github/workflows/pull_requests_tests.yaml
+++ b/.github/workflows/pull_requests_tests.yaml
@@ -7,6 +7,9 @@ on:
       - reopened
       - synchronize
 
+permissions:
+  contents: read
+
 jobs:
   static-checks:
     name: Static Checks

--- a/.github/workflows/pull_requests_tests.yaml
+++ b/.github/workflows/pull_requests_tests.yaml
@@ -27,3 +27,19 @@ jobs:
           GOLANGCI_LINT_VERSION: "1.44.2"
       - name: Run pre-commit
         uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
+
+  unit-tests:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Configure Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: 1.16.x
+      - name: Build
+        run: go build ./...
+      - name: Vet
+        run: go vet ./...
+      - name: Test
+        run: go test ./...

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 - [github-flow-manager](#github-flow-manager)
   - [Help](#help)
   - [Example](#example)
+  - [How specific check names are evaluated](#how-specific-check-names-are-evaluated)
   - [Pre commit](#pre-commit)
   - [Expressions](#expressions)
     - [Available variables](#available-variables)
@@ -37,6 +38,8 @@ Usage:
   github-flow-manager [OWNER] [REPOSITORY] [SOURCE_BRANCH] [DESTINATION_BRANCH] [EXPRESSION] [SPECIFIC_COMMIT_CHECK_NAME - Optional] [flags]
 
 Flags:
+      --accept-skipped-checks
+                              Accept a required check GitHub reports as SKIPPED as satisfied
   -c, --commits-number int    Number of commits to get under evaluation (>0, <=100) (default 100)
   -d, --dry-run               Don't modify repository
   -f, --force                 Use the force Luke... - Changes branch HEAD with force
@@ -60,6 +63,45 @@ GITHUB_TOKEN=xxx github-flow-manager octocat Hello-World test master "StatusSucc
 GITHUB_TOKEN=xxx github-flow-manager octocat Hello-World test master "StatusSuccess == false" "pipeline-name-to-be-checked" --verbose --dry-run
 GITHUB_TOKEN=xxx github-flow-manager octocat Hello-World test master "StatusSuccess == false" "pipeline-1-name-to-be-checked,pipeline-2-name-to-be-checked" --verbose --dry-run
 ```
+
+## How specific check names are evaluated
+
+When `SPECIFIC_COMMIT_CHECK_NAME` is given, every name in it is evaluated
+**separately**, and `StatusSuccess` is true only when **all** of them are
+satisfied. A name is satisfied when:
+
+- at least one result on the commit carries that name - otherwise the check
+  never ran and the commit is not promotable;
+- no result for that name is still queued or in progress, so a promotion can
+  never pre-empt a verdict; and
+- every concluded result for that name concluded `SUCCESS`.
+
+Only `SUCCESS` satisfies a required check. `NEUTRAL` deliberately does **not**:
+`devops-pipelines`' `hotfix_aware_skip_check` publishes `hotfix-skip-tests` as
+`SUCCESS` to mean "authorised to promote without tests" and `NEUTRAL` to mean
+"not a hotfix", and repositories gate their hotfix promote on that single name,
+so accepting `NEUTRAL` would turn a fail-closed gate into a fail-open one.
+
+A name may legitimately be reported **more than once** - a merge queue builds a
+commit twice, once for the queue run and once for the push run, and a reusable
+workflow called by several callers publishes its check once per caller. Several
+results for one name are fine as long as they are all green. A name can also be
+reported as a commit status context, as the name of a workflow, or as the name of
+a check run; all three are searched.
+
+`SKIPPED` does not satisfy a required check either, unless
+`--accept-skipped-checks` is passed. Prefer solving a legitimate skip *upstream*,
+by publishing one aggregator check that is only ever `success` or `failure` -
+`dbt-app`'s `dbt-app CI merge readiness` and `noa-whisper-app`'s
+`all_builds_passed` both do this - so the promotion gate never has to interpret a
+skip.
+
+Without `SPECIFIC_COMMIT_CHECK_NAME`, `StatusSuccess` comes from GitHub's own
+status check rollup for the commit, unchanged.
+
+With `--verbose`, any commit held back by its required checks is listed under the
+table with one line per required name, so a stalled promotion can be diagnosed
+from the job log.
 
 ## Pre commit
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -13,12 +13,13 @@ import (
 )
 
 var (
-	commitsNumber *int
-	githubToken   *string
-	force         *bool
-	verbose       *bool
-	dryRun        *bool
-	separator     *string
+	commitsNumber       *int
+	githubToken         *string
+	force               *bool
+	verbose             *bool
+	dryRun              *bool
+	separator           *string
+	acceptSkippedChecks *bool
 )
 
 const (
@@ -68,7 +69,7 @@ If a SPECIFIC_COMMIT_CHECK_NAME is specified, the StatusSuccess will be calculat
 			*githubToken = os.Getenv("GITHUB_TOKEN")
 		}
 
-		results, err := flow_manager.Manage(*githubToken, owner, repo, sourceBranch, destinationBranch, expression, specificChecksNames, *separator, *commitsNumber, *force, *dryRun)
+		results, err := flow_manager.Manage(*githubToken, owner, repo, sourceBranch, destinationBranch, expression, specificChecksNames, *separator, *acceptSkippedChecks, *commitsNumber, *force, *dryRun)
 		if err != nil {
 			fmt.Println(err.Error())
 			os.Exit(1)
@@ -105,6 +106,21 @@ If a SPECIFIC_COMMIT_CHECK_NAME is specified, the StatusSuccess will be calculat
 
 		table.Render()
 
+		// Without this, a commit held back by its required checks looks
+		// identical to one held back by the expression, which makes a stalled
+		// promotion very hard to diagnose from the job log alone.
+		for _, res := range results {
+			c := res.Commit
+			if c.StatusSuccess || len(c.ChecksSummary) == 0 {
+				continue
+			}
+
+			fmt.Println("Required checks not satisfied for " + c.SHA + ":")
+			for _, line := range c.ChecksSummary {
+				fmt.Println("\t" + line)
+			}
+		}
+
 		endingMessage := "THERE IS NO COMMITS PASSING EVALUATION"
 		if results[len(results)-1].Result {
 			endingMessage = "NO MORE COMMITS WERE EXAMINED BECAUSE LAST ONE EVALUATED SUCCESSFULLY"
@@ -127,4 +143,5 @@ func init() {
 	verbose = rootCmd.Flags().BoolP("verbose", "v", false, "Print table with commits evaluation status")
 	dryRun = rootCmd.Flags().BoolP("dry-run", "d", false, "Don't modify repository")
 	separator = rootCmd.Flags().StringP("separator", "s", ",", "Set string separator of status checks")
+	acceptSkippedChecks = rootCmd.Flags().Bool("accept-skipped-checks", false, "Accept a required check GitHub reports as SKIPPED as satisfied (off by default: only SUCCESS satisfies a required check)")
 }

--- a/github/checks.go
+++ b/github/checks.go
@@ -1,0 +1,225 @@
+package github
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/shurcooL/githubv4"
+)
+
+// checkOutcome is the normalised outcome of a single result that GitHub
+// reported for a required check name.
+type checkOutcome int
+
+const (
+	// outcomePassed means the result is green, or green enough to promote.
+	outcomePassed checkOutcome = iota
+	// outcomePending means the result has not concluded yet, so promoting now
+	// would pre-empt its verdict.
+	outcomePending
+	// outcomeFailed means the result concluded in a state that is not green.
+	outcomeFailed
+)
+
+// checkResult is one result on a commit that carries a required check name,
+// together with the raw state GitHub reported, kept for the operator-facing
+// summary.
+type checkResult struct {
+	outcome checkOutcome
+	verdict string
+}
+
+// noVerdictYet is shown for a result GitHub has not concluded yet.
+const noVerdictYet = "NO_CONCLUSION_YET"
+
+// splitCheckNames splits the required check names supplied on the command line,
+// dropping whitespace and empty entries so that a stray separator (`a,b,` or
+// `a, b`) cannot silently add a name that can never be satisfied.
+func splitCheckNames(specificChecksNames, sep string) []string {
+	var names []string
+	for _, name := range strings.Split(specificChecksNames, sep) {
+		if trimmed := strings.TrimSpace(name); trimmed != "" {
+			names = append(names, trimmed)
+		}
+	}
+
+	return names
+}
+
+// classifyConclusion maps the conclusion of a check suite or a check run onto a
+// checkOutcome.
+//
+// Only SUCCESS satisfies a required check, which is exactly the acceptance rule
+// the previous implementation applied - this change fixes how results are
+// counted, deliberately without widening what counts as green.
+//
+// NEUTRAL in particular must not satisfy anything. devops-pipelines'
+// hotfix_aware_skip_check workflow publishes its `hotfix-skip-tests` check as
+// SUCCESS to mean "this commit is authorised to promote without tests" and
+// NEUTRAL to mean "not a hotfix", and repositories gate their hotfix promote on
+// that single name. Accepting NEUTRAL would turn that gate from fail-closed into
+// fail-open and let any commit promote untested.
+//
+// SKIPPED satisfies only when acceptSkipped is set, for repositories that skip a
+// required job on purpose - see the --accept-skipped-checks flag.
+func classifyConclusion(conclusion githubv4.String, acceptSkipped bool) checkOutcome {
+	if conclusion == "" {
+		// GitHub reports a null conclusion until the suite or run completes.
+		return outcomePending
+	}
+
+	switch githubv4.CheckConclusionState(conclusion) {
+	case githubv4.CheckConclusionStateSuccess:
+		return outcomePassed
+	case githubv4.CheckConclusionStateSkipped:
+		if acceptSkipped {
+			return outcomePassed
+		}
+		return outcomeFailed
+	default:
+		return outcomeFailed
+	}
+}
+
+// classifyCheckRun classifies a single check run. Its status wins over its
+// conclusion: a run that has not completed cannot have a trustworthy verdict.
+func classifyCheckRun(checkRun CheckRunNodes, acceptSkipped bool) checkResult {
+	if checkRun.Status != "" && githubv4.CheckStatusState(checkRun.Status) != githubv4.CheckStatusStateCompleted {
+		return checkResult{outcome: outcomePending, verdict: string(checkRun.Status)}
+	}
+
+	return checkResult{outcome: classifyConclusion(checkRun.Conclusion, acceptSkipped), verdict: verdictOf(checkRun.Conclusion)}
+}
+
+// verdictOf renders a conclusion for the summary, naming the empty case.
+func verdictOf(conclusion githubv4.String) string {
+	if conclusion == "" {
+		return noVerdictYet
+	}
+
+	return string(conclusion)
+}
+
+// classifyStatusContext classifies a single commit status context. Commit
+// statuses carry no conclusion, only a state.
+func classifyStatusContext(ctx Context) checkResult {
+	result := checkResult{verdict: string(ctx.State)}
+
+	switch githubv4.StatusState(ctx.State) {
+	case githubv4.StatusStateSuccess:
+		result.outcome = outcomePassed
+	case githubv4.StatusStatePending, githubv4.StatusStateExpected:
+		result.outcome = outcomePending
+	default:
+		// ERROR, FAILURE, or a state this build does not recognise.
+		result.outcome = outcomeFailed
+	}
+
+	return result
+}
+
+// collectResults gathers every result on the commit that carries the given
+// required check name.
+//
+// The same name can reach us through three different GitHub concepts - a commit
+// status context, the name of a workflow run, and the name of a check run - so
+// all three are searched. One name legitimately matching several results is
+// normal: while a merge queue is active, a commit is built twice, once for the
+// queue run and once for the push run, and both report the same workflow name.
+func collectResults(name string, edge Edge, acceptSkipped bool) []checkResult {
+	var results []checkResult
+
+	// A commit status set directly on the commit (the classic statuses API).
+	for _, ctx := range edge.Node.Status.Contexts {
+		if githubv4.String(name) == ctx.Context {
+			results = append(results, classifyStatusContext(ctx))
+		}
+	}
+
+	for _, checkSuite := range edge.Node.CheckSuites.Nodes {
+		// The required name can be the name of the workflow itself, in which
+		// case the suite's conclusion is the workflow run's verdict.
+		if (checkSuite.WorkflowRun != WorkflowRun{}) && githubv4.String(name) == checkSuite.WorkflowRun.Workflow.Name {
+			conclusion := checkSuite.WorkflowRun.CheckSuite.Conclusion
+			results = append(results, checkResult{
+				outcome: classifyConclusion(conclusion, acceptSkipped),
+				verdict: verdictOf(conclusion),
+			})
+		}
+
+		// Or the name of an individual check run inside the suite, which is how
+		// a required "workflow / job" check appears.
+		for _, checkRun := range checkSuite.CheckRuns.Nodes {
+			if githubv4.String(name) == checkRun.Name {
+				results = append(results, classifyCheckRun(checkRun, acceptSkipped))
+			}
+		}
+	}
+
+	return results
+}
+
+// evaluateCheckName applies "nothing missing, nothing pending, nothing red" to a
+// single required check name and returns whether it is satisfied plus a line for
+// the summary.
+func evaluateCheckName(name string, edge Edge, acceptSkipped bool) (bool, string) {
+	results := collectResults(name, edge, acceptSkipped)
+	if len(results) == 0 {
+		return false, fmt.Sprintf("%s: NEVER RAN - no commit status, workflow run or check run carries this name", name)
+	}
+
+	verdicts := make([]string, 0, len(results))
+	var pending, failed int
+	for _, result := range results {
+		verdicts = append(verdicts, result.verdict)
+		switch result.outcome {
+		case outcomePending:
+			pending++
+		case outcomeFailed:
+			failed++
+		case outcomePassed:
+		}
+	}
+	reported := fmt.Sprintf("%s: %d result(s) [%s]", name, len(results), strings.Join(verdicts, " "))
+
+	switch {
+	case failed > 0:
+		return false, reported + fmt.Sprintf(" - %d did not pass", failed)
+	case pending > 0:
+		return false, reported + fmt.Sprintf(" - %d still running", pending)
+	}
+
+	return true, "OK " + reported
+}
+
+// evaluateSpecificChecks reports whether every required check name is satisfied
+// on the commit, along with a per-name summary.
+//
+// Every name is evaluated on its own. An earlier implementation summed the
+// successful results across all names and compared that total to the number of
+// names, which meant a surplus on one name could silently cover a deficit on
+// another - promoting commits whose required checks had never gone green - while
+// a name reporting more than one successful result pushed the total past the
+// exact-equality test and blocked commits where everything had in fact passed.
+// Duplicate results per name are routine, which is what made both directions of
+// that bug reachable: a merge queue builds a commit twice, and a reusable
+// workflow called by several callers reports its check once per caller.
+func evaluateSpecificChecks(edge Edge, checkNames []string, acceptSkipped bool) (bool, []string) {
+	if len(checkNames) == 0 {
+		// Names were asked for but none are usable. Fail closed: an empty
+		// requirement set would make every commit vacuously promotable.
+		return false, []string{"no usable required check names were supplied - refusing to promote"}
+	}
+
+	statusSuccess := true
+	summary := make([]string, 0, len(checkNames))
+	for _, name := range checkNames {
+		passed, line := evaluateCheckName(name, edge, acceptSkipped)
+		if !passed {
+			statusSuccess = false
+		}
+		summary = append(summary, line)
+	}
+
+	return statusSuccess, summary
+}

--- a/github/checks_test.go
+++ b/github/checks_test.go
@@ -1,0 +1,484 @@
+package github
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/shurcooL/githubv4"
+)
+
+// The required check names DocPlanner/dbt-app promotes on. They are used
+// throughout these tests because the defect this file guards against was found
+// on that repository.
+const (
+	checkBuildPush = "build_push / build_push-dbt"
+	checkAppTests  = "run_app_tests"
+	checkDbtTests  = "run_dbt_tests"
+)
+
+var dbtAppChecks = []string{checkBuildPush, checkAppTests, checkDbtTests}
+
+// completedRun builds a check run that finished with the given conclusion.
+func completedRun(name string, conclusion githubv4.CheckConclusionState) CheckRunNodes {
+	return CheckRunNodes{
+		Name:       githubv4.String(name),
+		Status:     githubv4.String(githubv4.CheckStatusStateCompleted),
+		Conclusion: githubv4.String(conclusion),
+	}
+}
+
+// unfinishedRun builds a check run that has not concluded yet, the way GitHub
+// reports it: a non-completed status and a null conclusion.
+func unfinishedRun(name string, status githubv4.CheckStatusState) CheckRunNodes {
+	return CheckRunNodes{
+		Name:   githubv4.String(name),
+		Status: githubv4.String(status),
+	}
+}
+
+// edgeWithRuns puts every check run in its own check suite, which is how GitHub
+// reports runs that came from separate workflow runs - for instance the same
+// workflow executed once for a merge-queue run and once for the push run.
+func edgeWithRuns(runs ...CheckRunNodes) Edge {
+	suites := make([]CheckSuiteNode, 0, len(runs))
+	for _, run := range runs {
+		suites = append(suites, CheckSuiteNode{CheckRuns: CheckRuns{Nodes: []CheckRunNodes{run}}})
+	}
+
+	return Edge{Node: EdgeRootNode{CheckSuites: CheckSuites{Nodes: suites}}}
+}
+
+// edgeWithStatusContexts builds a commit carrying classic commit statuses rather
+// than check runs.
+func edgeWithStatusContexts(contexts ...Context) Edge {
+	return Edge{Node: EdgeRootNode{Status: NodeStatus{Contexts: contexts}}}
+}
+
+// edgeWithWorkflowRun builds a commit whose required name is the name of a
+// workflow, so the verdict lives on the check suite of its workflow run.
+func edgeWithWorkflowRun(workflow string, conclusion githubv4.CheckConclusionState) Edge {
+	return Edge{Node: EdgeRootNode{CheckSuites: CheckSuites{Nodes: []CheckSuiteNode{{
+		WorkflowRun: WorkflowRun{
+			Workflow:   Workflow{Name: githubv4.String(workflow)},
+			CheckSuite: CheckSuite{Conclusion: githubv4.String(conclusion)},
+		},
+	}}}}}
+}
+
+// TestDuplicateSuccessNoLongerMasksAFailure covers the historical false pass.
+//
+// The old implementation summed successes across all names and compared the
+// total to the number of names, so two successful runs of one check paid for a
+// second check that had failed outright: 1 + 2 + 0 = 3 == 3 names, promoted.
+func TestDuplicateSuccessNoLongerMasksAFailure(t *testing.T) {
+	edge := edgeWithRuns(
+		completedRun(checkBuildPush, githubv4.CheckConclusionStateSuccess),
+		completedRun(checkAppTests, githubv4.CheckConclusionStateSuccess),
+		completedRun(checkAppTests, githubv4.CheckConclusionStateSuccess),
+		completedRun(checkDbtTests, githubv4.CheckConclusionStateFailure),
+	)
+
+	statusSuccess, summary := evaluateSpecificChecks(edge, dbtAppChecks, false)
+
+	if statusSuccess {
+		t.Fatalf("a commit whose %s failed must not be promotable, summary: %v", checkDbtTests, summary)
+	}
+	assertSummaryMentions(t, summary, checkDbtTests, "did not pass")
+}
+
+// TestDuplicateSuccessNoLongerMasksAMissingCheck covers the same false pass for
+// a required check that never produced any run at all, which is what the
+// evidence commit 7d7d1c8b looked like from the gate's point of view: the total
+// reached the required count while one name had never gone green.
+func TestDuplicateSuccessNoLongerMasksAMissingCheck(t *testing.T) {
+	edge := edgeWithRuns(
+		completedRun(checkBuildPush, githubv4.CheckConclusionStateSuccess),
+		completedRun(checkAppTests, githubv4.CheckConclusionStateSuccess),
+		completedRun(checkAppTests, githubv4.CheckConclusionStateSuccess),
+	)
+
+	statusSuccess, summary := evaluateSpecificChecks(edge, dbtAppChecks, false)
+
+	if statusSuccess {
+		t.Fatalf("a commit missing %s entirely must not be promotable, summary: %v", checkDbtTests, summary)
+	}
+	assertSummaryMentions(t, summary, checkDbtTests, "NEVER RAN")
+}
+
+// TestExtraSuccessfulRunNoLongerBlocks covers the historical false block. Every
+// required check passed, but one of them ran twice, so the old exact-equality
+// test saw 4 successes against 3 names and refused to promote.
+func TestExtraSuccessfulRunNoLongerBlocks(t *testing.T) {
+	edge := edgeWithRuns(
+		completedRun(checkBuildPush, githubv4.CheckConclusionStateSuccess),
+		completedRun(checkAppTests, githubv4.CheckConclusionStateSuccess),
+		completedRun(checkAppTests, githubv4.CheckConclusionStateSuccess),
+		completedRun(checkDbtTests, githubv4.CheckConclusionStateSuccess),
+	)
+
+	statusSuccess, summary := evaluateSpecificChecks(edge, dbtAppChecks, false)
+
+	if !statusSuccess {
+		t.Fatalf("every required check passed, so a duplicate run must not block promotion, summary: %v", summary)
+	}
+}
+
+// TestSkippedPolicyIsOptIn pins down the one deliberate policy choice here.
+//
+// The fixture is the exact evidence from DocPlanner/dbt-app commit 7d7d1c8b,
+// built while a merge queue was active: run_app_tests reported twice (queue run
+// plus push run) and run_dbt_tests skipped. The old rule counted 1 + 2 + 0 = 3
+// against 3 names and promoted it, even though run_dbt_tests had never gone
+// green.
+//
+// SKIPPED does not satisfy a required check by default, which is what the old
+// rule did too - it only ever counted SUCCESS. Repositories that skip a required
+// job on purpose opt in with --accept-skipped-checks.
+func TestSkippedPolicyIsOptIn(t *testing.T) {
+	edge := edgeWithRuns(
+		completedRun(checkBuildPush, githubv4.CheckConclusionStateSuccess),
+		completedRun(checkAppTests, githubv4.CheckConclusionStateSuccess),
+		completedRun(checkAppTests, githubv4.CheckConclusionStateSuccess),
+		completedRun(checkDbtTests, githubv4.CheckConclusionStateSkipped),
+	)
+
+	statusSuccess, summary := evaluateSpecificChecks(edge, dbtAppChecks, false)
+	if statusSuccess {
+		t.Fatalf("by default a skipped required check must not satisfy the gate, summary: %v", summary)
+	}
+	assertSummaryMentions(t, summary, checkDbtTests, "did not pass")
+
+	if statusSuccess, summary := evaluateSpecificChecks(edge, dbtAppChecks, true); !statusSuccess {
+		t.Fatalf("with acceptSkippedChecks a skipped required check must be accepted, summary: %v", summary)
+	}
+}
+
+// TestNeutralNeverSatisfies guards a fail-closed gate that several repositories
+// depend on and that no flag may open.
+//
+// devops-pipelines' hotfix_aware_skip_check workflow publishes its
+// hotfix-skip-tests check as SUCCESS to mean "this commit is authorised to
+// promote without tests" and NEUTRAL to mean "not a hotfix". monolith-app gates
+// its hotfix promote on that single name with StatusSuccess == true, so treating
+// NEUTRAL as satisfied would let any ordinary commit promote untested.
+func TestNeutralNeverSatisfies(t *testing.T) {
+	const hotfixSkipTests = "hotfix-skip-tests"
+	names := []string{hotfixSkipTests}
+
+	for _, acceptSkipped := range []bool{false, true} {
+		edge := edgeWithRuns(completedRun(hotfixSkipTests, githubv4.CheckConclusionStateNeutral))
+
+		statusSuccess, summary := evaluateSpecificChecks(edge, names, acceptSkipped)
+		if statusSuccess {
+			t.Fatalf("a neutral %s must never authorise promotion (acceptSkippedChecks=%t), summary: %v", hotfixSkipTests, acceptSkipped, summary)
+		}
+	}
+
+	// And the authorised case still promotes.
+	edge := edgeWithRuns(completedRun(hotfixSkipTests, githubv4.CheckConclusionStateSuccess))
+	if statusSuccess, summary := evaluateSpecificChecks(edge, names, false); !statusSuccess {
+		t.Fatalf("a successful %s must authorise promotion, summary: %v", hotfixSkipTests, summary)
+	}
+}
+
+// TestSingleNameReportedTwiceStillPromotes covers the false block for the very
+// common single-required-name repositories. A reusable workflow called by several
+// callers publishes its check once per caller, so one name routinely resolves to
+// several successful results - and the old exact-equality test then saw 2 != 1
+// and refused to promote a fully green commit. monolith-app's hotfix path
+// (hotfix-skip-tests) is one of these.
+func TestSingleNameReportedTwiceStillPromotes(t *testing.T) {
+	const loadContext = "load_context / Load context"
+	edge := edgeWithRuns(
+		completedRun(loadContext, githubv4.CheckConclusionStateSuccess),
+		completedRun(loadContext, githubv4.CheckConclusionStateSuccess),
+		completedRun(loadContext, githubv4.CheckConclusionStateSuccess),
+		completedRun(loadContext, githubv4.CheckConclusionStateSuccess),
+	)
+
+	statusSuccess, summary := evaluateSpecificChecks(edge, []string{loadContext}, false)
+	if !statusSuccess {
+		t.Fatalf("four successful results for the only required name must promote, summary: %v", summary)
+	}
+}
+
+// TestPendingResultsBlock makes sure the gate never pre-empts a verdict, whether
+// GitHub signals "not finished" through the run's status or through a null
+// conclusion.
+func TestPendingResultsBlock(t *testing.T) {
+	tests := map[string]Edge{
+		"queued check run": edgeWithRuns(
+			completedRun(checkBuildPush, githubv4.CheckConclusionStateSuccess),
+			completedRun(checkAppTests, githubv4.CheckConclusionStateSuccess),
+			unfinishedRun(checkDbtTests, githubv4.CheckStatusStateQueued),
+		),
+		"in progress check run": edgeWithRuns(
+			completedRun(checkBuildPush, githubv4.CheckConclusionStateSuccess),
+			completedRun(checkAppTests, githubv4.CheckConclusionStateSuccess),
+			unfinishedRun(checkDbtTests, githubv4.CheckStatusStateInProgress),
+		),
+		"successful run alongside one still in progress": edgeWithRuns(
+			completedRun(checkBuildPush, githubv4.CheckConclusionStateSuccess),
+			completedRun(checkAppTests, githubv4.CheckConclusionStateSuccess),
+			completedRun(checkDbtTests, githubv4.CheckConclusionStateSuccess),
+			unfinishedRun(checkDbtTests, githubv4.CheckStatusStateInProgress),
+		),
+		"workflow run with no conclusion yet": Edge{Node: EdgeRootNode{CheckSuites: CheckSuites{Nodes: []CheckSuiteNode{
+			{CheckRuns: CheckRuns{Nodes: []CheckRunNodes{completedRun(checkBuildPush, githubv4.CheckConclusionStateSuccess)}}},
+			{CheckRuns: CheckRuns{Nodes: []CheckRunNodes{completedRun(checkAppTests, githubv4.CheckConclusionStateSuccess)}}},
+			{WorkflowRun: WorkflowRun{Workflow: Workflow{Name: githubv4.String(checkDbtTests)}}},
+		}}}},
+		"pending commit status": edgeWithStatusContexts(
+			Context{Context: checkBuildPush, State: githubv4.String(githubv4.StatusStateSuccess)},
+			Context{Context: checkAppTests, State: githubv4.String(githubv4.StatusStateSuccess)},
+			Context{Context: checkDbtTests, State: githubv4.String(githubv4.StatusStatePending)},
+		),
+	}
+
+	for name, edge := range tests {
+		t.Run(name, func(t *testing.T) {
+			statusSuccess, summary := evaluateSpecificChecks(edge, dbtAppChecks, false)
+			if statusSuccess {
+				t.Fatalf("promoting now would pre-empt the verdict of %s, summary: %v", checkDbtTests, summary)
+			}
+		})
+	}
+}
+
+// TestFailingConclusionsBlock walks every conclusion that must stop a promotion,
+// each reported for one required name while the other two are green.
+func TestFailingConclusionsBlock(t *testing.T) {
+	blocking := []githubv4.CheckConclusionState{
+		githubv4.CheckConclusionStateFailure,
+		githubv4.CheckConclusionStateCancelled,
+		githubv4.CheckConclusionStateTimedOut,
+		githubv4.CheckConclusionStateActionRequired,
+		githubv4.CheckConclusionStateStale,
+		githubv4.CheckConclusionStateStartupFailure,
+		githubv4.CheckConclusionStateNeutral,
+		githubv4.CheckConclusionStateSkipped,
+	}
+
+	for _, conclusion := range blocking {
+		t.Run(string(conclusion), func(t *testing.T) {
+			edge := edgeWithRuns(
+				completedRun(checkBuildPush, githubv4.CheckConclusionStateSuccess),
+				completedRun(checkAppTests, githubv4.CheckConclusionStateSuccess),
+				completedRun(checkDbtTests, conclusion),
+			)
+
+			statusSuccess, summary := evaluateSpecificChecks(edge, dbtAppChecks, false)
+			if statusSuccess {
+				t.Fatalf("%s must not be treated as green, summary: %v", conclusion, summary)
+			}
+		})
+	}
+}
+
+// TestAllGreenPasses is the happy path, once per source GitHub can report a
+// required name through.
+func TestAllGreenPasses(t *testing.T) {
+	tests := map[string]Edge{
+		"check runs": edgeWithRuns(
+			completedRun(checkBuildPush, githubv4.CheckConclusionStateSuccess),
+			completedRun(checkAppTests, githubv4.CheckConclusionStateSuccess),
+			completedRun(checkDbtTests, githubv4.CheckConclusionStateSuccess),
+		),
+		"commit statuses": edgeWithStatusContexts(
+			Context{Context: checkBuildPush, State: githubv4.String(githubv4.StatusStateSuccess)},
+			Context{Context: checkAppTests, State: githubv4.String(githubv4.StatusStateSuccess)},
+			Context{Context: checkDbtTests, State: githubv4.String(githubv4.StatusStateSuccess)},
+		),
+	}
+
+	for name, edge := range tests {
+		t.Run(name, func(t *testing.T) {
+			statusSuccess, summary := evaluateSpecificChecks(edge, dbtAppChecks, false)
+			if !statusSuccess {
+				t.Fatalf("all required checks are green, summary: %v", summary)
+			}
+			for _, line := range summary {
+				if !strings.HasPrefix(line, "OK ") {
+					t.Errorf("expected every summary line to report OK, got %q", line)
+				}
+			}
+		})
+	}
+}
+
+// TestErroredCommitStatusBlocks covers the commit-status path for a red verdict,
+// which has no conclusion of its own, only a state.
+func TestErroredCommitStatusBlocks(t *testing.T) {
+	for _, state := range []githubv4.StatusState{githubv4.StatusStateFailure, githubv4.StatusStateError} {
+		t.Run(string(state), func(t *testing.T) {
+			edge := edgeWithStatusContexts(
+				Context{Context: checkBuildPush, State: githubv4.String(githubv4.StatusStateSuccess)},
+				Context{Context: checkAppTests, State: githubv4.String(githubv4.StatusStateSuccess)},
+				Context{Context: checkDbtTests, State: githubv4.String(state)},
+			)
+
+			statusSuccess, summary := evaluateSpecificChecks(edge, dbtAppChecks, false)
+			if statusSuccess {
+				t.Fatalf("a commit status of %s must block promotion, summary: %v", state, summary)
+			}
+		})
+	}
+}
+
+// TestWorkflowRunNameIsMatched keeps the workflow-name path working: a required
+// name can be the name of a whole workflow rather than of a single check run.
+func TestWorkflowRunNameIsMatched(t *testing.T) {
+	names := []string{checkAppTests}
+
+	if statusSuccess, summary := evaluateSpecificChecks(edgeWithWorkflowRun(checkAppTests, githubv4.CheckConclusionStateSuccess), names, false); !statusSuccess {
+		t.Fatalf("a successful workflow run must satisfy its required name, summary: %v", summary)
+	}
+
+	statusSuccess, summary := evaluateSpecificChecks(edgeWithWorkflowRun(checkAppTests, githubv4.CheckConclusionStateFailure), names, false)
+	if statusSuccess {
+		t.Fatalf("a failed workflow run must block promotion, summary: %v", summary)
+	}
+}
+
+// TestMissingNameBlocks checks the simplest case of all: a required name that
+// nothing on the commit reports.
+func TestMissingNameBlocks(t *testing.T) {
+	edge := edgeWithRuns(completedRun("some_other_check", githubv4.CheckConclusionStateSuccess))
+
+	statusSuccess, summary := evaluateSpecificChecks(edge, []string{checkAppTests}, false)
+	if statusSuccess {
+		t.Fatalf("a required check that never ran must block promotion, summary: %v", summary)
+	}
+	assertSummaryMentions(t, summary, checkAppTests, "NEVER RAN")
+}
+
+// TestNoUsableCheckNamesFailsClosed makes sure an empty requirement set is never
+// read as "everything passed".
+func TestNoUsableCheckNamesFailsClosed(t *testing.T) {
+	edge := edgeWithRuns(completedRun(checkAppTests, githubv4.CheckConclusionStateSuccess))
+
+	statusSuccess, summary := evaluateSpecificChecks(edge, nil, false)
+	if statusSuccess {
+		t.Fatalf("an empty set of required names must not promote anything, summary: %v", summary)
+	}
+}
+
+func TestSplitCheckNames(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		sep      string
+		expected []string
+	}{
+		{name: "single name", input: checkAppTests, sep: ",", expected: []string{checkAppTests}},
+		{
+			name:     "the dbt-app list",
+			input:    "run_app_tests,run_dbt_tests,build_push / build_push-dbt",
+			sep:      ",",
+			expected: []string{checkAppTests, checkDbtTests, checkBuildPush},
+		},
+		{name: "surrounding whitespace is dropped", input: "run_app_tests, run_dbt_tests", sep: ",", expected: []string{checkAppTests, checkDbtTests}},
+		{name: "trailing separator adds no phantom name", input: "run_app_tests,run_dbt_tests,", sep: ",", expected: []string{checkAppTests, checkDbtTests}},
+		{name: "custom separator", input: "run_app_tests;run_dbt_tests", sep: ";", expected: []string{checkAppTests, checkDbtTests}},
+		{name: "nothing usable", input: " , ", sep: ",", expected: nil},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := splitCheckNames(test.input, test.sep)
+			if len(got) != len(test.expected) {
+				t.Fatalf("splitCheckNames(%q, %q) = %v, want %v", test.input, test.sep, got, test.expected)
+			}
+			for i, name := range got {
+				if name != test.expected[i] {
+					t.Errorf("splitCheckNames(%q, %q)[%d] = %q, want %q", test.input, test.sep, i, name, test.expected[i])
+				}
+			}
+		})
+	}
+}
+
+// TestHydrateCommitsFallsBackToRollup guards the untouched path: with no
+// specific check names, StatusSuccess still comes straight from GitHub's status
+// rollup and no per-name summary is produced.
+func TestHydrateCommitsFallsBackToRollup(t *testing.T) {
+	tests := map[string]struct {
+		rollupState githubv4.StatusState
+		expected    bool
+	}{
+		"successful rollup": {rollupState: githubv4.StatusStateSuccess, expected: true},
+		"failing rollup":    {rollupState: githubv4.StatusStateFailure, expected: false},
+		"pending rollup":    {rollupState: githubv4.StatusStatePending, expected: false},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			// A red check run on the commit as well, to prove the rollup alone
+			// decides on this path.
+			edge := edgeWithRuns(completedRun(checkAppTests, githubv4.CheckConclusionStateFailure))
+			edge.Node.Oid = "cafebabe"
+			edge.Node.StatusCheckRollup = StatusCheckRollup{State: githubv4.String(test.rollupState)}
+
+			commits := hydrateCommits(queryWithEdges(edge), "", ",", false)
+
+			if len(commits) != 1 {
+				t.Fatalf("expected exactly one hydrated commit, got %d", len(commits))
+			}
+			if commits[0].StatusSuccess != test.expected {
+				t.Errorf("StatusSuccess = %t for a %s rollup, want %t", commits[0].StatusSuccess, test.rollupState, test.expected)
+			}
+			if len(commits[0].ChecksSummary) != 0 {
+				t.Errorf("expected no per-name summary on the rollup path, got %v", commits[0].ChecksSummary)
+			}
+		})
+	}
+}
+
+// TestHydrateCommitsWithSpecificChecks checks the wiring from the command-line
+// string through to a commit's StatusSuccess and summary.
+func TestHydrateCommitsWithSpecificChecks(t *testing.T) {
+	edge := edgeWithRuns(
+		completedRun(checkBuildPush, githubv4.CheckConclusionStateSuccess),
+		completedRun(checkAppTests, githubv4.CheckConclusionStateSuccess),
+		completedRun(checkAppTests, githubv4.CheckConclusionStateSuccess),
+		completedRun(checkDbtTests, githubv4.CheckConclusionStateSkipped),
+	)
+	edge.Node.Oid = "7d7d1c8b"
+	// A green rollup, to prove it is ignored once specific names are requested.
+	edge.Node.StatusCheckRollup = StatusCheckRollup{State: githubv4.String(githubv4.StatusStateSuccess)}
+	names := strings.Join(dbtAppChecks, ",")
+
+	commits := hydrateCommits(queryWithEdges(edge), names, ",", false)
+	if len(commits) != 1 || commits[0].StatusSuccess {
+		t.Fatalf("expected the commit to be blocked by its skipped required check, got %+v", commits)
+	}
+	if len(commits[0].ChecksSummary) != len(dbtAppChecks) {
+		t.Errorf("expected one summary line per required name, got %v", commits[0].ChecksSummary)
+	}
+	assertSummaryMentions(t, commits[0].ChecksSummary, checkDbtTests, "did not pass")
+
+	commits = hydrateCommits(queryWithEdges(edge), names, ",", true)
+	if len(commits) != 1 || !commits[0].StatusSuccess {
+		t.Fatalf("expected the commit to be promotable with acceptSkippedChecks, got %+v", commits)
+	}
+}
+
+// queryWithEdges wraps commit edges in the response shape the GraphQL query
+// returns.
+func queryWithEdges(edges ...Edge) *Query {
+	return &Query{Repository: Repository{Ref: Ref{Target: Target{Commit: TargetCommit{History: History{Edges: edges}}}}}}
+}
+
+// assertSummaryMentions fails the test unless some summary line names the given
+// check and contains the given reason.
+func assertSummaryMentions(t *testing.T, summary []string, name, reason string) {
+	t.Helper()
+
+	for _, line := range summary {
+		if strings.Contains(line, name) && strings.Contains(line, reason) {
+			return
+		}
+	}
+
+	t.Errorf("expected a summary line about %q containing %q, got %v", name, reason, summary)
+}

--- a/github/commit.go
+++ b/github/commit.go
@@ -4,10 +4,14 @@ import "time"
 
 // Commit represents a specific GitHub commit
 type Commit struct {
-	SHA                 string
-	Message             string
-	Parents             []Commit
-	StatusSuccess       bool
+	SHA           string
+	Message       string
+	Parents       []Commit
+	StatusSuccess bool
+	// ChecksSummary explains, one line per required check name, why
+	// StatusSuccess came out the way it did. Empty when no specific check names
+	// were requested and the GitHub status rollup was used instead.
+	ChecksSummary       []string
 	AuthoredDate        time.Time
 	AuthorName          string
 	SpecificCheckPassed bool

--- a/github/manager.go
+++ b/github/manager.go
@@ -2,7 +2,6 @@ package github
 
 import (
 	"net/http"
-	"strings"
 
 	"github.com/google/go-github/github"
 	"github.com/shurcooL/githubv4"
@@ -29,8 +28,11 @@ func New(githubAccessToken string) *Manager {
 	return &Manager{Context: ctx, Client: client, HTTPClient: httpClient}
 }
 
-// GetCommits recover the commits for a specific repository in a specific branch
-func (gm *Manager) GetCommits(owner, repo, branch string, lastCommitsNumber int, specificChecksNames string, sep string) ([]Commit, error) {
+// GetCommits recover the commits for a specific repository in a specific branch.
+// When specificChecksNames is set, every name it contains must be satisfied on a
+// commit for its StatusSuccess to be true; acceptSkippedChecks additionally lets
+// a check GitHub reports as SKIPPED count as satisfied.
+func (gm *Manager) GetCommits(owner, repo, branch string, lastCommitsNumber int, specificChecksNames string, sep string, acceptSkippedChecks bool) ([]Commit, error) {
 	if lastCommitsNumber > 100 || lastCommitsNumber < 1 {
 		return nil, &Error{Message: "lastCommitsNumber must be a number between 1 and 100"} // TODO maybe in future implement pagination
 	}
@@ -49,7 +51,7 @@ func (gm *Manager) GetCommits(owner, repo, branch string, lastCommitsNumber int,
 		return nil, err
 	}
 
-	return hydrateCommits(q, specificChecksNames, sep), nil
+	return hydrateCommits(q, specificChecksNames, sep, acceptSkippedChecks), nil
 }
 
 // PickFirstParentCommits recover the first parent commit of a commit history from a repository
@@ -102,26 +104,7 @@ func (gm *Manager) ChangeBranchHead(owner, repo, branch, sha string, force bool)
 	return nil
 }
 
-func checkRunSet(checksPassed *int, cn string, edge Edge) {
-	for _, checkSuite := range edge.Node.CheckSuites.Nodes {
-		if (checkSuite.WorkflowRun != WorkflowRun{}) && githubv4.String(cn) == checkSuite.WorkflowRun.Workflow.Name {
-			if checkSuite.WorkflowRun.CheckSuite.Conclusion == githubv4.String(githubv4.StatusStateSuccess) {
-				*checksPassed++
-				continue
-			}
-		}
-
-		for _, checkRuns := range checkSuite.CheckRuns.Nodes {
-			if githubv4.String(cn) == checkRuns.Name {
-				if checkRuns.Conclusion == githubv4.String(githubv4.StatusStateSuccess) {
-					*checksPassed++
-				}
-			}
-		}
-	}
-}
-
-func hydrateCommits(q *Query, specificChecksNames string, sep string) []Commit {
+func hydrateCommits(q *Query, specificChecksNames string, sep string, acceptSkippedChecks bool) []Commit {
 
 	var fullCommitsList []Commit
 	for _, edge := range q.Repository.Ref.Target.Commit.History.Edges {
@@ -133,30 +116,14 @@ func hydrateCommits(q *Query, specificChecksNames string, sep string) []Commit {
 			})
 		}
 
-		statusSuccess := false
-		checkNames := strings.Split(specificChecksNames, sep)
-		numChecks := len(checkNames)
-		checksPassed := 0
-
-		for _, cn := range checkNames {
-			// first check if commit has commit status set
-			for _, ctx := range edge.Node.Status.Contexts {
-				if githubv4.String(cn) == ctx.Context {
-					if ctx.State == githubv4.String(githubv4.StatusStateSuccess) {
-						checksPassed++
-					}
-				}
-			}
-
-			checkRunSet(&checksPassed, cn, edge)
-		}
-
-		if checksPassed == numChecks {
-			statusSuccess = true
-		}
+		var statusSuccess bool
+		var checksSummary []string
 
 		if specificChecksNames == "" {
+			// No specific names were asked for, so trust GitHub's own rollup.
 			statusSuccess = edge.Node.StatusCheckRollup.State == githubv4.String(githubv4.StatusStateSuccess)
+		} else {
+			statusSuccess, checksSummary = evaluateSpecificChecks(edge, splitCheckNames(specificChecksNames, sep), acceptSkippedChecks)
 		}
 
 		fullCommitsList = append(fullCommitsList, Commit{
@@ -164,6 +131,7 @@ func hydrateCommits(q *Query, specificChecksNames string, sep string) []Commit {
 			Message:       string(edge.Node.Message),
 			Parents:       parents,
 			StatusSuccess: statusSuccess,
+			ChecksSummary: checksSummary,
 			AuthoredDate:  edge.Node.AuthoredDate.Time,
 			AuthorName:    string(edge.Node.Author.Name),
 		})

--- a/manager/flow-manager.go
+++ b/manager/flow-manager.go
@@ -18,20 +18,20 @@ func checkGithubToken(githubToken string) error {
 }
 
 // Manage will do the necessary actions to move the head from one branch to another
-func Manage(githubToken, owner, repo, sourceBranch, destinationBranch, expression string, specificChecksNames string, sep string, lastCommitsNumber int, force, dryRun bool) ([]EvaluationResult, error) {
+func Manage(githubToken, owner, repo, sourceBranch, destinationBranch, expression string, specificChecksNames string, sep string, acceptSkippedChecks bool, lastCommitsNumber int, force, dryRun bool) ([]EvaluationResult, error) {
 	err := checkGithubToken(githubToken)
 	if err != nil {
 		return nil, err
 	}
 	parsedExpression := expr.MustParse(expression)
 	gm := github.New(githubToken)
-	commits, err := gm.GetCommits(owner, repo, sourceBranch, lastCommitsNumber, specificChecksNames, sep)
+	commits, err := gm.GetCommits(owner, repo, sourceBranch, lastCommitsNumber, specificChecksNames, sep, acceptSkippedChecks)
 	if nil != err {
 		return nil, err
 	}
 	firstParentCommits := github.PickFirstParentCommits(commits)
 
-	destinationCommits, err := gm.GetCommits(owner, repo, destinationBranch, 1, specificChecksNames, sep)
+	destinationCommits, err := gm.GetCommits(owner, repo, destinationBranch, 1, specificChecksNames, sep, acceptSkippedChecks)
 	if nil != err {
 		return nil, err
 	}


### PR DESCRIPTION
## The defect

Promotion was authorised by **counting** successful check results across *all*
required names and comparing that total to the *number* of names
(`github/manager.go`, `hydrateCommits` + `checkRunSet`):

```go
for _, cn := range checkNames {
    for _, ctx := range edge.Node.Status.Contexts { /* +1 per SUCCESS */ }
    checkRunSet(&checksPassed, cn, edge)              // +1 per successful run
}
if checksPassed == numChecks { statusSuccess = true }
```

`checksPassed` is one flat counter. It never verified that **each** required name
passed, so:

* a **surplus** on one name silently covered a **deficit** on another, and
* the **exact-equality** test rejected commits where everything passed but one
  name produced two successful runs.

Duplicate results per name are not exotic here — they are routine. A merge queue
builds a commit twice (queue run + push run), and a reusable workflow called by
several callers publishes its check once per caller: on `monolith-app`'s current
`develop` HEAD, `load_context / Load context` appears **4×**.

## Evidence from DocPlanner/dbt-app

Required checks at the time: `run_app_tests,run_dbt_tests,build_push / build_push-dbt`.

While a merge queue was active, a `develop` commit produced `run_app_tests`
**twice**:

| name | runs | contributes |
|---|---|---|
| `build_push / build_push-dbt` | 1 × success | 1 |
| `run_app_tests` | 2 × success | 2 |
| `run_dbt_tests` | 1 × **skipped** | 0 |

Total 3, `numChecks` 3 → **promoted to `master` while `run_dbt_tests` was never
green.** Verified on commit `7d7d1c8b`.

The merge queue then stopped being used on 2026-08-03. `run_app_tests` dropped to
one run, so the best any commit could score became 1+1+0 = **2 ≠ 3**, and
promotion became structurally impossible: `master` sat unchanged from 2026-08-03
to 2026-08-07 while the job kept exiting 0 and reporting
`THERE IS NO COMMITS PASSING EVALUATION`. Verified counts on `0e6dae35`,
`268fa5a3`, `11f61a6a`, `bd917063`, `b28faf42`.

One defect, both directions, silent in both.

## The fix

Per-name coverage instead of a sum. For each required name:

1. at least one result must carry that name (else: *never ran*),
2. none may still be queued / in progress (else promotion pre-empts the verdict),
3. every concluded result must have concluded `SUCCESS`.

Several results for one name are fine as long as they are all green.

**The acceptance predicate is deliberately unchanged — `SUCCESS` only, exactly
what the old counter accepted.** This is a counting fix, not a widening of what
counts as green, so no repository starts promoting on a verdict it did not
already accept.

<details>
<summary>Old vs. new on the same fixtures (generated from the committed test fixtures)</summary>

```
scenario                                         | old   | new   | new --accept-skipped-checks
dbt-app 7d7d1c8b: 1 ok + 2 ok + 1 SKIPPED        | true  | false | true
masked FAILURE: 1 ok + 2 ok + 1 FAILURE          | true  | false | false
masked MISSING: 1 ok + 2 ok + name absent        | true  | false | false
all green, one ran twice (4 successes / 3 names) | false | true  | true
all green, one per name                          | true  | true  | true
post-queue freeze: 1 ok + 1 ok + 1 SKIPPED       | false | false | true
monolith hotfix gate: 1x NEUTRAL (not a hotfix)  | false | false | false
monolith hotfix gate: 1x SUCCESS (authorised)    | true  | true  | true
single name reported twice, both SUCCESS         | false | true  | true
single name: 1 SUCCESS + 1 FAILURE               | true  | false | false
in progress                                      | false | false | false
```

Note the second-to-last row: with a **single** required name, one success plus one
**failure** counted 1 == 1 and **promoted**. That is the masking bug sitting on
the most dangerous gate we have — see the next section.

</details>

## ❓ Decision for maintainers: what should `SKIPPED` and `NEUTRAL` mean?

**This is a policy choice, not a technical inevitability, and I have deliberately
not encoded my own repo's preference as the default.** Please rule on it.

I set out to make `SKIPPED` and `NEUTRAL` *satisfy* a required name — that is
GitHub's own required-status-check semantics, and `dbt-app`'s `run_dbt_tests` is
legitimately skipped on `develop` pushes (change detection finds no dbt files,
because the merge-base diff of `develop` against itself is empty). **While
enumerating the blast radius I found that default would introduce a worse bug
than the one it fixes**, so I inverted it.

`devops-pipelines/.github/workflows/hotfix_aware_skip_check.yml` publishes its
`hotfix-skip-tests` check as **`success` = "this commit is authorised to promote
without tests"** and **`neutral` = "not a hotfix"**:

```js
} else {
  conclusion = 'neutral';
  title = `Not a ${labelName}`;
```

`monolith-app/.github/workflows/hotfix.yaml` then gates the irreversible promote
on exactly that one name:

```yaml
  promote:
    uses: docplanner/devops-pipelines/.github/workflows/promote_commit_to_master.yml@v1
    with:
      expression: ${{ github.event_name == 'workflow_dispatch' && 'true' || 'StatusSuccess == true' }}
      status_check_names: 'hotfix-skip-tests'
```

Accepting `NEUTRAL` would flip that gate from fail-closed to **fail-open**: every
ordinary commit would satisfy `StatusSuccess == true` on the hotfix path and
promote untested. So, as shipped here:

* **`NEUTRAL` never satisfies**, and no flag can make it — a flag would just
  relocate the footgun. Same as today's behaviour.
* **`SKIPPED` does not satisfy by default**, also same as today, with
  `--accept-skipped-checks` as an opt-in for repos that skip a required job on
  purpose.

`dbt-app` does **not** need that flag, because it already solved the skip
*upstream*: as of `7431e918` its `required_checks` are
`dbt-app CI merge readiness,build_push / build_push-dbt`, where
`dbt-app CI merge readiness` is an `if: always()` aggregator that accepts
`success|skipped` per tracked job and emits a single literal green/red check.
`noa-whisper-app` does the same with `all_builds_passed`. **That is the pattern
worth recommending to other teams**, and it keeps working under per-name coverage.

Open questions for you:

1. Is `--accept-skipped-checks` worth keeping at all, or should teams always be
   pushed to the aggregator pattern? I kept it because it is nearly free, but I
   have no consumer for it — including my own repo.
2. Should `NEUTRAL` stay permanently non-satisfying, or become configurable once
   the `hotfix-skip-tests` contract lives somewhere more durable than a workflow
   comment?

## Blast radius

One invocation point, ~143 consumers, no staged rollout by default.

* **Every caller funnels through
  `DocPlanner/devops-pipelines/.github/workflows/promote_commit_to_master.yml`**
  (job `promote`, `docker run ghcr.io/docplanner/github-flow-manager:${{ inputs.ghfm_version }}`).
  Nothing in the org invokes the binary directly.
* **143 distinct repositories** call that reusable workflow, across **172 caller
  workflow files**. `software-templates` skeletons carry the same pattern, so
  future repos inherit it.
* **122 repositories pass `status_check_names` on at least one path → affected by
  this change.** Most resolve the names from their own `.github/cicd.yml`
  (`context.release.required_checks` / `hotfix_required_checks`);
  `noa-notes-app` / `noa-notes-front-app` use `context.promote.required_checks`,
  and `noa-second-opinion-app` uses a 4-entry matrix.
* **21 repositories never pass names on any path** → `specificChecksNames == ""`
  → the `StatusCheckRollup` fallback → **completely unaffected**. That path is
  untouched and now has a regression test (`TestHydrateCommitsFallsBackToRollup`).
  They are `.github-private`, `ai-plugin-manager`, `backuper-app`, `crm-app`,
  `deployments-app`, `deployments-front-app`, `gmb-app`, `integrations-app`,
  `invoicing-app`, `legal-operations-front-app`, `manually-generated-sitemaps`,
  `marketplace-account-app`, `messenger-front-app`,
  `noa-notes-integration-docs`, `package-app-php-client`, `patient-request-app`,
  `payments-app`, `pdf-viewer-front-app`, `repman`, `restorer-app`,
  `watson-mobile`.
* Of the declared name lists, **47 are single-name** and 56 are multi-name.
* `ghfm_version` **defaults to `latest`**, and `.goreleaser.yml` moves
  `ghcr.io/docplanner/github-flow-manager:latest` on every `v*` tag. **Merging
  this PR ships nothing; tagging ships it to all 122 affected repos at once.**

### Who changes behaviour, and how

**Newly blocked — failures that were previously masked.** Any repo where the
successes happened to total N while some name was red, missing, or still pending.
Worst exposure is the **47 single-name** repos, where **one success plus one
failure counted 1 == 1 and promoted**: `monolith-app`'s hotfix path,
`authorization-app`, `one-app`, `one-front-app`, `booking-front-app`,
`platform-app`, `geocoder-app`, `crm-front-app`, `kraken-mcp-app`,
`package-gateway`, `rabbit-sidecar-app`, `permissions-portal-front-app`,
`revenue-features-front-app`, `widgets-front-app`, `noa-notes-hub-front-app`,
`noa-whisper-app`, `docker-jupyter-hub`, `terapia-app`, `websockets-app`, and
every other `build_push / build_push-*`-only repo. **This is the point of the
PR**, but it will surface previously invisible red checks as new promotion
blocks. Expect support questions.

**Newly promoting — commits previously blocked by an inflated count.** Same
single-name set: the moment a name resolved twice (routine for
reusable-workflow checks), `2 != 1` froze promotion silently. Those repos start
promoting again.

**Named, deliberate side effects:**

* `noa-second-opinion-app` declares
  `run_tests (app), build_push (app) / build_push-noa-second-opinion` — note the
  **space after the comma**. Today `strings.Split` yields a name with a leading
  space that can never match, so `numChecks=2` can only ever reach 1 and that
  repo's automated promotion is **currently dead**. This PR adds `TrimSpace`, so
  it will start promoting for the first time (correctly, on its real checks).
  Worth telling that team. Happy to drop the trimming if you would rather fix it
  in their config instead.
* `vendor-bills-es-app` has the literal `required_checks: '[]'`; `chat-app` and
  `opibot-app` set `hotfix_required_checks: 'build_push'` where the real check run
  is `build_push / build_push-<app>`. These are blocked today and stay blocked —
  but the `--verbose` output now says
  `NEVER RAN - no commit status, workflow run or check run carries this name`
  instead of a bare "no commits passing evaluation", so they become fixable
  config rather than a mystery.
* `phone-front-app` runs the inverted `expression: 'StatusSuccess == false'`, so
  per-name coverage changes *when* it promotes rather than *whether*. Flagged
  because the inversion makes the blast direction non-obvious.

## Known limitation, deliberately not fixed here: GraphQL page caps

`github/types.go` still hardcodes `checkSuites(first: 20)` and
`checkRuns(first: 25)`. `monolith-app`'s `develop` HEAD already carries **23
check suites** (atlantis, sentry, sonar, semgrep, claude, wip, dp-testings…), so
a required check can fall outside the window depending on ordering.

Truncation already blocks promotion today — a missing run also reduced the count —
so this PR does not make it worse. It does remove the accidental compensation
where a duplicate elsewhere covered a truncated one, and it makes truncation
*diagnosable* through the per-name summary. **I did not bundle a fix on purpose:**
#33 raised both caps to 100 and was fully reverted in #35 because it raised
GraphQL query cost ~20× (worst case ~2,526 points/call against the 5,000/hour
bucket). That needs real pagination, in its own PR. `post-office-app` (10 names)
and `secretary-ai-app` (7 names) are the other exposed consumers.

## Also in this PR

* **CI ran no tests at all** — `pull_requests_tests.yaml` only ran pre-commit.
  Added a `Unit Tests` job (`go build` / `go vet` / `go test`). It is not in
  branch protection; someone with admin should add it as required.
* **`--verbose` now explains why a commit was held back**, one line per required
  name. A commit blocked by its checks previously looked identical to one blocked
  by the expression — which is exactly why a four-day release freeze went
  unnoticed while the job reported success:

  ```
  Required checks not satisfied for 7d7d1c8b...:
      OK build_push / build_push-dbt: 1 result(s) [SUCCESS]
      OK run_app_tests: 2 result(s) [SUCCESS SUCCESS]
      run_dbt_tests: 1 result(s) [SKIPPED] - 1 did not pass
  ```
* Names are trimmed and empty entries dropped, so a stray separator (`a,b,`) no
  longer contributes a name that can never be satisfied. A list with nothing
  usable (e.g. `","`) now **fails closed** rather than promoting vacuously on an
  empty requirement set.
* Evaluation logic moved to `github/checks.go`; `checkRunSet` is gone.

## API surface

The CLI is unchanged apart from the new opt-in `--accept-skipped-checks`; the `,`
separator default in `cmd/root.go` is untouched. Two exported Go signatures gain
one `bool` parameter (`github.GetCommits`, `manager.Manage`) and `github.Commit`
gains a `ChecksSummary []string` field. All in-repo callers are updated; nothing
in the org imports the module — it is consumed as a container image.

## Verification

```
$ go build ./...   # ok
$ go vet ./...     # ok
$ go test ./...
ok  	github.com/Docplanner/github-flow-manager/github	0.551s
$ gofmt -l .       # clean
$ pre-commit run --all-files
Run go fmt against the code..............................................Passed
Trim Trailing Whitespace.................................................Passed
Fix End of Files.........................................................Passed
Check for merge conflicts................................................Passed
Mixed line ending........................................................Passed
Add TOC for md files.....................................................Passed
Run golangci against the code............................................Passed
```

40 test cases covering: the historical false-pass (duplicate success masking a
skip, a failure, and a missing name); the historical false-block (extra
successful run, and a single name reported twice); genuine failures across every
blocking conclusion; pending runs signalled both via `status` and via a null
`conclusion`; a missing name; all-green through check runs, commit statuses and
workflow-run names; the `monolith-app` `NEUTRAL` hotfix gate in both directions;
name splitting; and the untouched `StatusCheckRollup` fallback.

`golangci-lint` locally was **v2.12.2** (0 issues). The CI-pinned v1.44.2 will not
run under Go 1.26 (`panic: load embedded ruleguard rules`, unrelated to this
change), so that version is verified only by this PR's own CI run.

I also dry-ran the rebuilt binary against live `DocPlanner/dbt-app`
`develop → master` with `--dry-run`; both branches are currently at `97cee590`,
so it correctly short-circuited with
`IS ALREADY IN master branch. EXITING THE PROCESS WITHOUT ANY ACTION.`

## Suggested rollout

Merging is inert; **tagging is the deploy**. Because `ghfm_version` defaults to
`latest`, I would not let a tag move `latest` immediately:

1. Merge this PR.
2. Tag a version and have `monolith-app` and `dbt-app` pin `ghfm_version` to it
   explicitly for a few days — `monolith-app` because it owns the
   `hotfix-skip-tests` gate, `dbt-app` because it has the reproducer.
3. Then let `latest` move, and expect a short tail of "my repo stopped promoting"
   reports that are genuinely red checks the old counter was hiding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
