### PR TITLE
fix: evaluate status checks per name and page beyond the first 100

### DIFF
--- a/.github/workflows/pull_requests_tests.yaml
+++ b/.github/workflows/pull_requests_tests.yaml
@@ -31,6 +31,9 @@ jobs:
   unit-tests:
     name: Unit Tests
     runs-on: ubuntu-latest
+    # Reading the code is all this job does; nothing here writes back to the repository.
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v2
       - name: Configure Go

--- a/.github/workflows/pull_requests_tests.yaml
+++ b/.github/workflows/pull_requests_tests.yaml
@@ -27,3 +27,15 @@ jobs:
           GOLANGCI_LINT_VERSION: "1.44.2"
       - name: Run pre-commit
         uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
+
+  unit-tests:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Configure Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17
+      - name: Run tests
+        run: go test ./... -count=1

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,9 @@
 
 # Generated binary files
 bin
+
+# Promotion-verdict baselines (see testdata/baseline/README.md). Recorded output embeds commit
+# messages, author names and branch names; for private repositories that must not land in this
+# public repo. The harness is tracked, the repo list and the recordings are not.
+testdata/baseline/consumers.tsv
+testdata/baseline/*/

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 - [github-flow-manager](#github-flow-manager)
   - [Help](#help)
   - [Example](#example)
+    - [How status check names are resolved](#how-status-check-names-are-resolved)
   - [Pre commit](#pre-commit)
   - [Expressions](#expressions)
     - [Available variables](#available-variables)
@@ -37,14 +38,26 @@ Usage:
   github-flow-manager [OWNER] [REPOSITORY] [SOURCE_BRANCH] [DESTINATION_BRANCH] [EXPRESSION] [SPECIFIC_COMMIT_CHECK_NAME - Optional] [flags]
 
 Flags:
-  -c, --commits-number int    Number of commits to get under evaluation (>0, <=100) (default 100)
-  -d, --dry-run               Don't modify repository
-  -f, --force                 Use the force Luke... - Changes branch HEAD with force
-  -t, --github-token string   GitHub token (can be passed also as GITHUB_TOKEN env variable
-  -h, --help                  help for github-flow-manager
-  -v, --verbose               Print table with commits evaluation status
-  -s, --separator             Set string separator of status checks (default ,)
+  -c, --commits-number int      Number of commits to get under evaluation (>0, <=100) (default 100)
+      --check-suites-number int Check suites to fetch per commit in the first page (>0, <=100) (default 50)
+      --contexts-number int     Status checks to fetch per commit in the first page (>0, <=100) (default 50)
+  -d, --dry-run                 Don't modify repository
+  -f, --force                   Use the force Luke... - Changes branch HEAD with force
+  -t, --github-token string     GitHub token (can be passed also as GITHUB_TOKEN env variable
+  -h, --help                    help for github-flow-manager
+  -v, --verbose                 Print table with commits evaluation status
+  -s, --separator               Set string separator of status checks (default ,)
 ```
+
+`--contexts-number` and `--check-suites-number` size the *first* page of check data fetched per
+commit. GitHub caps both connections at 100 per page; anything beyond the first page is fetched on
+demand, only for commits that are examined and have not already passed. So these flags trade the
+number of API calls against the size of each one — lowering them does not cause checks to be missed.
+
+On a repository with a lot of CI, one request can take longer than GitHub is willing to spend on it
+and you get a `502` or `504` back instead of an answer. The server-side work is roughly
+`--commits-number × (--contexts-number + --check-suites-number)`, so lowering any of the three helps;
+lower `--commits-number` last, since that one does change which commits are considered.
 
 ## Example
 
@@ -60,6 +73,33 @@ GITHUB_TOKEN=xxx github-flow-manager octocat Hello-World test master "StatusSucc
 GITHUB_TOKEN=xxx github-flow-manager octocat Hello-World test master "StatusSuccess == false" "pipeline-name-to-be-checked" --verbose --dry-run
 GITHUB_TOKEN=xxx github-flow-manager octocat Hello-World test master "StatusSuccess == false" "pipeline-1-name-to-be-checked,pipeline-2-name-to-be-checked" --verbose --dry-run
 ```
+
+### How status check names are resolved
+
+Each name you pass is looked for in three places, because GitHub exposes checks in three different
+shapes and which one a given name lands in is not always obvious:
+
+- a **classic commit status** (what the Statuses API sets)
+- a **check run** (what a GitHub Actions job or a third-party app publishes)
+- a **workflow name**, in which case the conclusion of that workflow's check suite decides
+
+`StatusSuccess` is true only when *every* name you passed resolved to a success. A name is satisfied
+if any of the above succeeded for it, so it is safe for the same name to appear in more than one
+shape, and for a check to have been re-run several times — neither counts against the commit.
+
+Only the literal conclusion `SUCCESS` satisfies a name. `NEUTRAL` and `SKIPPED` do not.
+
+With `--verbose`, any commit that fails its checks is listed afterwards with the reason per name,
+which separates the two cases that otherwise look identical:
+
+```text
+UNSATISFIED STATUS CHECKS ("not found" means no status, check run or workflow of that name exists on the commit):
+  a1b2c3d4  failed: Backend tests
+  e5f6a7b8  not found: Backend tests
+```
+
+`not found` almost always means the configured name no longer matches anything the CI publishes —
+a different fix from a genuinely failing build.
 
 ## Pre commit
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,18 +7,21 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Docplanner/github-flow-manager/github"
 	flow_manager "github.com/Docplanner/github-flow-manager/manager"
 	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
 )
 
 var (
-	commitsNumber *int
-	githubToken   *string
-	force         *bool
-	verbose       *bool
-	dryRun        *bool
-	separator     *string
+	commitsNumber     *int
+	contextsNumber    *int
+	checkSuitesNumber *int
+	githubToken       *string
+	force             *bool
+	verbose           *bool
+	dryRun            *bool
+	separator         *string
 )
 
 const (
@@ -36,6 +39,50 @@ func checkMinimumArgs(args []string) error {
 		}
 	}
 	return nil
+}
+
+// printUnsatisfiedChecks explains why commits failed their status checks, per commit and per check
+// name. Without this a stuck promotion looks identical whether a check went red or the configured
+// name matches nothing on the commit at all — and those need opposite fixes.
+func printUnsatisfiedChecks(results []flow_manager.EvaluationResult) {
+	var lines []string
+
+	for _, res := range results {
+		if res.Commit.StatusSuccess || len(res.Commit.CheckResults) == 0 {
+			continue
+		}
+
+		byState := map[string][]string{}
+		var order []string
+		for _, cr := range res.Commit.CheckResults {
+			if cr.State == github.CheckPassed {
+				continue
+			}
+			label := cr.State.String()
+			if _, seen := byState[label]; !seen {
+				order = append(order, label)
+			}
+			byState[label] = append(byState[label], cr.Name)
+		}
+		if len(order) == 0 {
+			continue
+		}
+
+		var groups []string
+		for _, label := range order {
+			groups = append(groups, label+": "+strings.Join(byState[label], ", "))
+		}
+		lines = append(lines, "  "+res.Commit.SHA[:8]+"  "+strings.Join(groups, " | "))
+	}
+
+	if len(lines) == 0 {
+		return
+	}
+
+	fmt.Println("\nUNSATISFIED STATUS CHECKS (\"not found\" means no status, check run or workflow of that name exists on the commit):")
+	for _, l := range lines {
+		fmt.Println(l)
+	}
 }
 
 // rootCmd represents the root command
@@ -68,7 +115,7 @@ If a SPECIFIC_COMMIT_CHECK_NAME is specified, the StatusSuccess will be calculat
 			*githubToken = os.Getenv("GITHUB_TOKEN")
 		}
 
-		results, err := flow_manager.Manage(*githubToken, owner, repo, sourceBranch, destinationBranch, expression, specificChecksNames, *separator, *commitsNumber, *force, *dryRun)
+		results, err := flow_manager.Manage(*githubToken, owner, repo, sourceBranch, destinationBranch, expression, specificChecksNames, *separator, *commitsNumber, *contextsNumber, *checkSuitesNumber, *force, *dryRun)
 		if err != nil {
 			fmt.Println(err.Error())
 			os.Exit(1)
@@ -105,6 +152,8 @@ If a SPECIFIC_COMMIT_CHECK_NAME is specified, the StatusSuccess will be calculat
 
 		table.Render()
 
+		printUnsatisfiedChecks(results)
+
 		endingMessage := "THERE IS NO COMMITS PASSING EVALUATION"
 		if results[len(results)-1].Result {
 			endingMessage = "NO MORE COMMITS WERE EXAMINED BECAUSE LAST ONE EVALUATED SUCCESSFULLY"
@@ -122,6 +171,8 @@ func Execute() {
 
 func init() {
 	commitsNumber = rootCmd.Flags().IntP("commits-number", "c", 100, "Number of commits to get under evaluation (>0, <=100)")
+	contextsNumber = rootCmd.Flags().Int("contexts-number", 50, "Status checks to fetch per commit in the first page (>0, <=100). Anything beyond it is fetched on demand, so this trades API calls against page size rather than losing checks")
+	checkSuitesNumber = rootCmd.Flags().Int("check-suites-number", 50, "Check suites to fetch per commit in the first page (>0, <=100). Same trade-off as --contexts-number")
 	githubToken = rootCmd.Flags().StringP("github-token", "t", "", "GitHub token (can be passed also as GITHUB_TOKEN env variable")
 	force = rootCmd.Flags().BoolP("force", "f", false, "Use the force Luke... - Changes branch HEAD with force")
 	verbose = rootCmd.Flags().BoolP("verbose", "v", false, "Print table with commits evaluation status")

--- a/github/commit.go
+++ b/github/commit.go
@@ -2,13 +2,67 @@ package github
 
 import "time"
 
+// CheckState is the outcome of resolving one requested status check name against a commit.
+type CheckState int
+
+const (
+	// CheckNotFound means no status, check run or workflow of that name exists on the commit.
+	// Kept distinct from CheckFailed because the two call for opposite fixes: a wrong name in
+	// configuration versus a genuinely red build.
+	CheckNotFound CheckState = iota
+	// CheckPending means a check run of that name exists but has not completed.
+	CheckPending
+	// CheckFailed means it completed with any conclusion other than SUCCESS.
+	CheckFailed
+	// CheckPassed means at least one instance concluded SUCCESS.
+	CheckPassed
+)
+
+// String renders the state for the verbose commit table.
+func (s CheckState) String() string {
+	switch s {
+	case CheckPassed:
+		return "passed"
+	case CheckFailed:
+		return "failed"
+	case CheckPending:
+		return "pending"
+	default:
+		return "not found"
+	}
+}
+
+// CheckResult is how one requested status check name resolved for a commit. Reported so that a
+// commit which fails evaluation says why, rather than only that it failed.
+type CheckResult struct {
+	Name  string
+	State CheckState
+}
+
 // Commit represents a specific GitHub commit
 type Commit struct {
-	SHA                 string
-	Message             string
-	Parents             []Commit
-	StatusSuccess       bool
-	AuthoredDate        time.Time
-	AuthorName          string
-	SpecificCheckPassed bool
+	SHA           string
+	Message       string
+	Parents       []Commit
+	StatusSuccess bool
+	AuthoredDate  time.Time
+	AuthorName    string
+	CheckResults  []CheckResult
+
+	// checkNames are the names this commit was asked to satisfy, in the order given.
+	checkNames []string
+	// states accumulates the best-known state per name across however many pages were read.
+	states map[string]CheckState
+
+	// Cursors for the connections that GitHub caps at 100 per page. Non-empty HasNextPage means
+	// the commit was only partially read and TopUpChecks can fetch the rest.
+	suites   PageInfo
+	contexts PageInfo
+}
+
+// ChecksTruncated reports whether some of this commit's check data was left unread because a
+// connection had more pages. A commit that already passed needs no more data; one that did not may
+// only be failing because the deciding check was on a page nobody fetched.
+func (c *Commit) ChecksTruncated() bool {
+	return bool(c.suites.HasNextPage) || bool(c.contexts.HasNextPage)
 }

--- a/github/manager.go
+++ b/github/manager.go
@@ -10,6 +10,9 @@ import (
 	"golang.org/x/oauth2"
 )
 
+// maxPageSize is GitHub's per-connection limit for `first:`.
+const maxPageSize = 100
+
 // Manager represents the information necessary in Github to manage the repository
 type Manager struct {
 	Context    context.Context
@@ -30,23 +33,40 @@ func New(githubAccessToken string) *Manager {
 }
 
 // GetCommits recover the commits for a specific repository in a specific branch
-func (gm *Manager) GetCommits(owner, repo, branch string, lastCommitsNumber int, specificChecksNames string, sep string) ([]Commit, error) {
-	if lastCommitsNumber > 100 || lastCommitsNumber < 1 {
+func (gm *Manager) GetCommits(owner, repo, branch string, lastCommitsNumber int, specificChecksNames string, sep string, contextsNumber, checkSuitesNumber int) ([]Commit, error) {
+	if lastCommitsNumber > maxPageSize || lastCommitsNumber < 1 {
 		return nil, &Error{Message: "lastCommitsNumber must be a number between 1 and 100"} // TODO maybe in future implement pagination
+	}
+	if contextsNumber > maxPageSize || contextsNumber < 1 {
+		return nil, &Error{Message: "contextsNumber must be a number between 1 and 100"}
+	}
+	if checkSuitesNumber > maxPageSize || checkSuitesNumber < 1 {
+		return nil, &Error{Message: "checkSuitesNumber must be a number between 1 and 100"}
 	}
 
 	q := &Query{}
 
 	client := gm.Client
 	err := client.Query(gm.Context, &q, map[string]interface{}{
-		"owner":         githubv4.String(owner),
-		"name":          githubv4.String(repo),
-		"branch":        githubv4.String(branch),
-		"commitsNumber": githubv4.Int(lastCommitsNumber),
-		"parentsNumber": githubv4.Int(1),
+		"owner":             githubv4.String(owner),
+		"name":              githubv4.String(repo),
+		"branch":            githubv4.String(branch),
+		"commitsNumber":     githubv4.Int(lastCommitsNumber),
+		"parentsNumber":     githubv4.Int(1),
+		"contextsNumber":    githubv4.Int(contextsNumber),
+		"checkSuitesNumber": githubv4.Int(checkSuitesNumber),
 	})
 	if nil != err {
-		return nil, err
+		// A repository with a lot of CI can make this query exceed GitHub's own execution time
+		// limit, which surfaces as a 502 or 504 rather than as anything about the query. The
+		// server cost is roughly commits × (contexts + check suites), so say which knobs shrink it.
+		return nil, &Error{
+			Message: "Can not read commits of " + branch + " because: " + err.Error() +
+				"\nIf this is a gateway timeout, the repository has more CI than one request can" +
+				" carry: lower --commits-number, or --contexts-number/--check-suites-number" +
+				" (later pages are fetched on demand, so lowering them loses nothing).",
+			PreviousError: err,
+		}
 	}
 
 	return hydrateCommits(q, specificChecksNames, sep), nil
@@ -102,23 +122,161 @@ func (gm *Manager) ChangeBranchHead(owner, repo, branch, sha string, force bool)
 	return nil
 }
 
-func checkRunSet(checksPassed *int, cn string, edge Edge) {
-	for _, checkSuite := range edge.Node.CheckSuites.Nodes {
-		if (checkSuite.WorkflowRun != WorkflowRun{}) && githubv4.String(cn) == checkSuite.WorkflowRun.Workflow.Name {
-			if checkSuite.WorkflowRun.CheckSuite.Conclusion == githubv4.String(githubv4.StatusStateSuccess) {
-				*checksPassed++
-				continue
-			}
+// TopUpChecks reads the check data that did not fit in the first page and folds it into the
+// commit's verdict.
+//
+// Both statusCheckRollup.contexts and checkSuites are capped at 100 entries per page, and real
+// repositories exceed that. Rather than silently judging a commit on a partial view, fetch the
+// remaining pages — but only when it can still change the answer, which is why callers invoke this
+// per commit they actually examine rather than for the whole history up front. It stops as soon as
+// every requested name has passed.
+func (gm *Manager) TopUpChecks(owner, repo string, c *Commit) error {
+	if len(c.checkNames) == 0 {
+		return nil
+	}
+
+	for bool(c.contexts.HasNextPage) && !allPassed(c.states, c.checkNames) {
+		q := &CommitContextsQuery{}
+		err := gm.Client.Query(gm.Context, q, map[string]interface{}{
+			"owner":          githubv4.String(owner),
+			"name":           githubv4.String(repo),
+			"oid":            githubv4.GitObjectID(c.SHA),
+			"contextsNumber": githubv4.Int(maxPageSize),
+			"contextsAfter":  githubv4.String(c.contexts.EndCursor),
+		})
+		if nil != err {
+			return &Error{Message: "Can not read further status checks for " + c.SHA + " because: " + err.Error(), PreviousError: err}
 		}
 
-		for _, checkRuns := range checkSuite.CheckRuns.Nodes {
-			if githubv4.String(cn) == checkRuns.Name {
-				if checkRuns.Conclusion == githubv4.String(githubv4.StatusStateSuccess) {
-					*checksPassed++
-				}
+		page := q.Repository.Object.Commit.StatusCheckRollup.Contexts
+		applyRollupContexts(c.states, page.Nodes)
+		c.contexts = page.PageInfo
+	}
+
+	for bool(c.suites.HasNextPage) && !allPassed(c.states, c.checkNames) {
+		q := &CommitSuitesQuery{}
+		err := gm.Client.Query(gm.Context, q, map[string]interface{}{
+			"owner":             githubv4.String(owner),
+			"name":              githubv4.String(repo),
+			"oid":               githubv4.GitObjectID(c.SHA),
+			"checkSuitesNumber": githubv4.Int(maxPageSize),
+			"suitesAfter":       githubv4.String(c.suites.EndCursor),
+		})
+		if nil != err {
+			return &Error{Message: "Can not read further check suites for " + c.SHA + " because: " + err.Error(), PreviousError: err}
+		}
+
+		page := q.Repository.Object.Commit.CheckSuites
+		applyCheckSuites(c.states, page.Nodes)
+		c.suites = page.PageInfo
+	}
+
+	c.settle()
+
+	return nil
+}
+
+// promote raises a name's state, never lowers it. A check that succeeded stays succeeded: the same
+// name legitimately appears more than once — as both a classic status and a check run, or as
+// several re-runs — and the commit should be judged on the best of them rather than on how many
+// times it was seen.
+func promote(states map[string]CheckState, name string, state CheckState) {
+	if current, ok := states[name]; !ok || state > current {
+		states[name] = state
+	}
+}
+
+// applyClassicStatuses folds in the commit's classic commit statuses.
+func applyClassicStatuses(states map[string]CheckState, contexts []Context) {
+	for _, ctx := range contexts {
+		name := string(ctx.Context)
+		if _, requested := states[name]; !requested {
+			continue
+		}
+
+		if ctx.State == githubv4.String(githubv4.StatusStateSuccess) {
+			promote(states, name, CheckPassed)
+			continue
+		}
+		promote(states, name, CheckFailed)
+	}
+}
+
+// applyRollupContexts folds in the status-check rollup, which carries both classic statuses and
+// check runs, latest-per-name.
+func applyRollupContexts(states map[string]CheckState, nodes []RollupContext) {
+	for _, node := range nodes {
+		switch node.Typename {
+		case "StatusContext":
+			name := string(node.StatusContext.Context)
+			if _, requested := states[name]; !requested {
+				continue
 			}
+
+			if node.StatusContext.State == githubv4.String(githubv4.StatusStateSuccess) {
+				promote(states, name, CheckPassed)
+				continue
+			}
+			promote(states, name, CheckFailed)
+
+		case "CheckRun":
+			name := string(node.CheckRun.Name)
+			if _, requested := states[name]; !requested {
+				continue
+			}
+
+			if node.CheckRun.Conclusion == githubv4.String(githubv4.StatusStateSuccess) {
+				promote(states, name, CheckPassed)
+				continue
+			}
+			if node.CheckRun.Status != githubv4.String(githubv4.CheckStatusStateCompleted) {
+				promote(states, name, CheckPending)
+				continue
+			}
+			promote(states, name, CheckFailed)
 		}
 	}
+}
+
+// applyCheckSuites folds in whole-workflow results: a requested name may be the name of a GitHub
+// Actions workflow rather than of an individual check, in which case the suite's conclusion decides.
+func applyCheckSuites(states map[string]CheckState, nodes []CheckSuiteNode) {
+	for _, suite := range nodes {
+		if (suite.WorkflowRun == WorkflowRun{}) {
+			continue
+		}
+
+		name := string(suite.WorkflowRun.Workflow.Name)
+		if _, requested := states[name]; !requested {
+			continue
+		}
+
+		if suite.WorkflowRun.CheckSuite.Conclusion == githubv4.String(githubv4.StatusStateSuccess) {
+			promote(states, name, CheckPassed)
+			continue
+		}
+		promote(states, name, CheckFailed)
+	}
+}
+
+// allPassed reports whether every requested name has been satisfied.
+func allPassed(states map[string]CheckState, names []string) bool {
+	for _, name := range names {
+		if states[name] != CheckPassed {
+			return false
+		}
+	}
+	return true
+}
+
+// settle publishes the accumulated per-name states as the commit's verdict. Safe to call again
+// after more pages are read.
+func (c *Commit) settle() {
+	c.CheckResults = make([]CheckResult, 0, len(c.checkNames))
+	for _, name := range c.checkNames {
+		c.CheckResults = append(c.CheckResults, CheckResult{Name: name, State: c.states[name]})
+	}
+	c.StatusSuccess = allPassed(c.states, c.checkNames)
 }
 
 func hydrateCommits(q *Query, specificChecksNames string, sep string) []Commit {
@@ -133,40 +291,35 @@ func hydrateCommits(q *Query, specificChecksNames string, sep string) []Commit {
 			})
 		}
 
-		statusSuccess := false
-		checkNames := strings.Split(specificChecksNames, sep)
-		numChecks := len(checkNames)
-		checksPassed := 0
-
-		for _, cn := range checkNames {
-			// first check if commit has commit status set
-			for _, ctx := range edge.Node.Status.Contexts {
-				if githubv4.String(cn) == ctx.Context {
-					if ctx.State == githubv4.String(githubv4.StatusStateSuccess) {
-						checksPassed++
-					}
-				}
-			}
-
-			checkRunSet(&checksPassed, cn, edge)
-		}
-
-		if checksPassed == numChecks {
-			statusSuccess = true
+		commit := Commit{
+			SHA:          string(edge.Node.Oid),
+			Message:      string(edge.Node.Message),
+			Parents:      parents,
+			AuthoredDate: edge.Node.AuthoredDate.Time,
+			AuthorName:   string(edge.Node.Author.Name),
+			suites:       edge.Node.CheckSuites.PageInfo,
+			contexts:     edge.Node.StatusCheckRollup.Contexts.PageInfo,
 		}
 
 		if specificChecksNames == "" {
-			statusSuccess = edge.Node.StatusCheckRollup.State == githubv4.String(githubv4.StatusStateSuccess)
+			// No names requested: defer to GitHub's own aggregate verdict for the commit.
+			commit.StatusSuccess = edge.Node.StatusCheckRollup.State == githubv4.String(githubv4.StatusStateSuccess)
+			fullCommitsList = append(fullCommitsList, commit)
+			continue
 		}
 
-		fullCommitsList = append(fullCommitsList, Commit{
-			SHA:           string(edge.Node.Oid),
-			Message:       string(edge.Node.Message),
-			Parents:       parents,
-			StatusSuccess: statusSuccess,
-			AuthoredDate:  edge.Node.AuthoredDate.Time,
-			AuthorName:    string(edge.Node.Author.Name),
-		})
+		commit.checkNames = strings.Split(specificChecksNames, sep)
+		commit.states = make(map[string]CheckState, len(commit.checkNames))
+		for _, name := range commit.checkNames {
+			commit.states[name] = CheckNotFound
+		}
+
+		applyClassicStatuses(commit.states, edge.Node.Status.Contexts)
+		applyRollupContexts(commit.states, edge.Node.StatusCheckRollup.Contexts.Nodes)
+		applyCheckSuites(commit.states, edge.Node.CheckSuites.Nodes)
+		commit.settle()
+
+		fullCommitsList = append(fullCommitsList, commit)
 	}
 
 	return fullCommitsList

--- a/github/manager_test.go
+++ b/github/manager_test.go
@@ -7,15 +7,17 @@ import (
 	"github.com/shurcooL/githubv4"
 )
 
-// These are characterization tests: they pin the CURRENT behaviour of
-// hydrateCommits and PickFirstParentCommits, defects included. Cases that assert
-// a known defect are marked with a KNOWN DEFECT comment.
+// These began as characterization tests pinning the behaviour of hydrateCommits and
+// PickFirstParentCommits before the fix for issue #36, defects included. They were then ported to
+// the reshaped query with exactly the assertions for those defects flipped — each marked
+// "WAS A DEFECT, NOW FIXED" and stating what it used to assert. Every other expectation is
+// unchanged from the pre-fix run, which is what makes them useful: a different one moving means
+// something regressed.
 //
-// Not covered here, deliberately: the defect where a required check falls outside
-// checkSuites(first: 20) / checkRuns(first: 25) and is therefore never seen. That is a
-// property of the GraphQL query, not of hydrateCommits — which only ever sees whatever
-// was already fetched, so a fixture holding 21 suites would simply have all 21 read.
-// It is covered instead by the end-to-end verdict baseline in testdata/baseline/.
+// Not covered here, deliberately: whether the query fetches enough of a commit's checks in the
+// first place. That is a property of the GraphQL query, not of hydrateCommits — which only ever
+// sees whatever was fetched — so no fixture can express it. TestChecksResolvedAcrossPages covers
+// the resolution half, and testdata/baseline/ covers it end to end against real repositories.
 
 // success is the only value hydrateCommits/checkRunSet treat as a passing check.
 const success = githubv4.String(githubv4.StatusStateSuccess)
@@ -49,31 +51,56 @@ func withStatusContext(n EdgeRootNode, name, state string) EdgeRootNode {
 	return n
 }
 
-func checkRun(name, conclusion string) CheckRunNodes {
-	return CheckRunNodes{
-		Name:       githubv4.String(name),
-		Conclusion: githubv4.String(conclusion),
+// checkRun builds a completed CheckRun member of the statusCheckRollup contexts union.
+func checkRun(name, conclusion string) RollupContext {
+	return RollupContext{
+		Typename: "CheckRun",
+		CheckRun: RollupCheckRun{
+			Name:       githubv4.String(name),
+			Status:     githubv4.String(githubv4.CheckStatusStateCompleted),
+			Conclusion: githubv4.String(conclusion),
+		},
 	}
 }
 
-// withCheckRunSuite adds a check suite whose WorkflowRun is the zero value, so
-// checkRunSet only looks at its CheckRuns.Nodes.
-func withCheckRunSuite(n EdgeRootNode, runs ...CheckRunNodes) EdgeRootNode {
-	n.CheckSuites.Nodes = append(n.CheckSuites.Nodes, CheckSuiteNode{
-		CheckRuns: CheckRuns{Nodes: runs},
-	})
+// pendingCheckRun builds a CheckRun that has not finished, so it has no conclusion yet.
+func pendingCheckRun(name string) RollupContext {
+	return RollupContext{
+		Typename: "CheckRun",
+		CheckRun: RollupCheckRun{
+			Name:   githubv4.String(name),
+			Status: githubv4.String(githubv4.CheckStatusStateInProgress),
+		},
+	}
+}
+
+// rollupStatusContext builds the StatusContext member of the same union — a classic commit status
+// as reported through the rollup rather than through Commit.status.
+func rollupStatusContext(name, state string) RollupContext {
+	return RollupContext{
+		Typename: "StatusContext",
+		StatusContext: RollupStatusContext{
+			Context: githubv4.String(name),
+			State:   githubv4.String(state),
+		},
+	}
+}
+
+// withCheckRuns adds entries to the commit's statusCheckRollup contexts, which is where check runs
+// are read from.
+func withCheckRuns(n EdgeRootNode, runs ...RollupContext) EdgeRootNode {
+	n.StatusCheckRollup.Contexts.Nodes = append(n.StatusCheckRollup.Contexts.Nodes, runs...)
 	return n
 }
 
 // withWorkflowSuite adds a check suite identified by its workflow name, whose
 // verdict lives in WorkflowRun.CheckSuite.Conclusion.
-func withWorkflowSuite(n EdgeRootNode, workflowName, conclusion string, runs ...CheckRunNodes) EdgeRootNode {
+func withWorkflowSuite(n EdgeRootNode, workflowName, conclusion string) EdgeRootNode {
 	n.CheckSuites.Nodes = append(n.CheckSuites.Nodes, CheckSuiteNode{
 		WorkflowRun: WorkflowRun{
 			Workflow:   Workflow{Name: githubv4.String(workflowName)},
 			CheckSuite: CheckSuite{Conclusion: githubv4.String(conclusion)},
 		},
-		CheckRuns: CheckRuns{Nodes: runs},
 	})
 	return n
 }
@@ -112,7 +139,7 @@ func TestHydrateCommits(t *testing.T) {
 		},
 		{
 			name:   "check run with SUCCESS conclusion passes",
-			nodes:  []EdgeRootNode{withCheckRunSuite(commitNode("sha1", "msg1"), checkRun("ci", string(success)))},
+			nodes:  []EdgeRootNode{withCheckRuns(commitNode("sha1", "msg1"), checkRun("ci", string(success)))},
 			checks: "ci",
 			sep:    ",",
 			want:   []bool{true},
@@ -125,41 +152,74 @@ func TestHydrateCommits(t *testing.T) {
 			want:   []bool{true},
 		},
 		{
-			// KNOWN DEFECT (double count): the requested name is found twice —
-			// once as a classic status, once as a check run — so checksPassed
-			// reaches 2 while numChecks is 1, and the `checksPassed == numChecks`
-			// gate rejects a commit whose check actually succeeded. A later step
-			// will intentionally flip this expectation to true.
-			name: "same name as both classic status and check run is double counted and fails",
-			nodes: []EdgeRootNode{withCheckRunSuite(
+			// WAS A DEFECT, NOW FIXED: this expectation was false. The name was found twice —
+			// once as a classic status, once as a check run — which drove checksPassed to 2
+			// against numChecks of 1, so the old `checksPassed == numChecks` gate rejected a
+			// commit whose check had in fact succeeded. State per name replaces the counter.
+			// Observed live on a consumer repository that publishes its aggregate required check
+			// both ways on the same commit.
+			name: "same name as both classic status and check run passes",
+			nodes: []EdgeRootNode{withCheckRuns(
 				withStatusContext(commitNode("sha1", "msg1"), "ci", string(success)),
 				checkRun("ci", string(success)),
 			)},
 			checks: "ci",
 			sep:    ",",
-			want:   []bool{false},
+			want:   []bool{true},
 		},
 		{
-			// KNOWN DEFECT (double count): re-runs produce several check runs with
-			// the same name; each SUCCESS increments the counter. A later step will
-			// intentionally flip this expectation to true.
-			name: "duplicate successful check runs in one suite are double counted and fail",
-			nodes: []EdgeRootNode{withCheckRunSuite(
+			// WAS A DEFECT, NOW FIXED: this expectation was false. Re-runs produce several check
+			// runs of the same name and each success used to increment the counter past numChecks.
+			name: "duplicate successful check runs of the same name pass",
+			nodes: []EdgeRootNode{withCheckRuns(
 				commitNode("sha1", "msg1"),
 				checkRun("ci", string(success)),
 				checkRun("ci", string(success)),
 			)},
 			checks: "ci",
 			sep:    ",",
-			want:   []bool{false},
+			want:   []bool{true},
 		},
 		{
-			// KNOWN DEFECT (double count): same as above, across two suites.
-			// A later step will intentionally flip this expectation to true.
-			name: "duplicate successful check runs across suites are double counted and fail",
-			nodes: []EdgeRootNode{withCheckRunSuite(
-				withCheckRunSuite(commitNode("sha1", "msg1"), checkRun("ci", string(success))),
+			// WAS A DEFECT, NOW FIXED: this expectation was false. As above, with the duplicates
+			// arriving from separate sources rather than together.
+			name: "duplicate successful check runs from separate sources pass",
+			nodes: []EdgeRootNode{withCheckRuns(
+				withCheckRuns(commitNode("sha1", "msg1"), checkRun("ci", string(success))),
 				checkRun("ci", string(success)),
+			)},
+			checks: "ci",
+			sep:    ",",
+			want:   []bool{true},
+		},
+		{
+			// A success anywhere satisfies the name: the old code already counted any matching
+			// success, so a name that both failed and succeeded must keep passing.
+			name: "name that failed in one place and succeeded in another passes",
+			nodes: []EdgeRootNode{withCheckRuns(
+				commitNode("sha1", "msg1"),
+				checkRun("ci", "FAILURE"),
+				checkRun("ci", string(success)),
+			)},
+			checks: "ci",
+			sep:    ",",
+			want:   []bool{true},
+		},
+		{
+			name: "classic status reported through the rollup passes",
+			nodes: []EdgeRootNode{withCheckRuns(
+				commitNode("sha1", "msg1"),
+				rollupStatusContext("ci", string(success)),
+			)},
+			checks: "ci",
+			sep:    ",",
+			want:   []bool{true},
+		},
+		{
+			name: "check run still running does not pass",
+			nodes: []EdgeRootNode{withCheckRuns(
+				commitNode("sha1", "msg1"),
+				pendingCheckRun("ci"),
 			)},
 			checks: "ci",
 			sep:    ",",
@@ -168,7 +228,7 @@ func TestHydrateCommits(t *testing.T) {
 		{
 			// A missing check is indistinguishable from a failing one.
 			name: "requested name absent from every source fails",
-			nodes: []EdgeRootNode{withCheckRunSuite(
+			nodes: []EdgeRootNode{withCheckRuns(
 				withStatusContext(commitNode("sha1", "msg1"), "other-status", string(success)),
 				checkRun("other-run", string(success)),
 			)},
@@ -178,21 +238,21 @@ func TestHydrateCommits(t *testing.T) {
 		},
 		{
 			name:   "check run with FAILURE conclusion fails",
-			nodes:  []EdgeRootNode{withCheckRunSuite(commitNode("sha1", "msg1"), checkRun("ci", "FAILURE"))},
+			nodes:  []EdgeRootNode{withCheckRuns(commitNode("sha1", "msg1"), checkRun("ci", "FAILURE"))},
 			checks: "ci",
 			sep:    ",",
 			want:   []bool{false},
 		},
 		{
 			name:   "check run with NEUTRAL conclusion fails",
-			nodes:  []EdgeRootNode{withCheckRunSuite(commitNode("sha1", "msg1"), checkRun("ci", "NEUTRAL"))},
+			nodes:  []EdgeRootNode{withCheckRuns(commitNode("sha1", "msg1"), checkRun("ci", "NEUTRAL"))},
 			checks: "ci",
 			sep:    ",",
 			want:   []bool{false},
 		},
 		{
 			name:   "check run with SKIPPED conclusion fails",
-			nodes:  []EdgeRootNode{withCheckRunSuite(commitNode("sha1", "msg1"), checkRun("ci", "SKIPPED"))},
+			nodes:  []EdgeRootNode{withCheckRuns(commitNode("sha1", "msg1"), checkRun("ci", "SKIPPED"))},
 			checks: "ci",
 			sep:    ",",
 			want:   []bool{false},
@@ -235,7 +295,7 @@ func TestHydrateCommits(t *testing.T) {
 		},
 		{
 			name: "two requested names with only one passing fails",
-			nodes: []EdgeRootNode{withCheckRunSuite(
+			nodes: []EdgeRootNode{withCheckRuns(
 				commitNode("sha1", "msg1"),
 				checkRun("a", string(success)),
 				checkRun("b", "FAILURE"),
@@ -246,7 +306,7 @@ func TestHydrateCommits(t *testing.T) {
 		},
 		{
 			name: "two requested names each passing once via a different source succeeds",
-			nodes: []EdgeRootNode{withCheckRunSuite(
+			nodes: []EdgeRootNode{withCheckRuns(
 				withStatusContext(commitNode("sha1", "msg1"), "a", string(success)),
 				checkRun("b", string(success)),
 			)},
@@ -256,7 +316,7 @@ func TestHydrateCommits(t *testing.T) {
 		},
 		{
 			name: "custom separator splits the requested names",
-			nodes: []EdgeRootNode{withCheckRunSuite(
+			nodes: []EdgeRootNode{withCheckRuns(
 				withStatusContext(commitNode("sha1", "msg1"), "a", string(success)),
 				checkRun("b", string(success)),
 			)},
@@ -267,8 +327,8 @@ func TestHydrateCommits(t *testing.T) {
 		{
 			name: "each commit in the history is evaluated independently and in order",
 			nodes: []EdgeRootNode{
-				withCheckRunSuite(commitNode("sha1", "msg1"), checkRun("ci", string(success))),
-				withCheckRunSuite(commitNode("sha2", "msg2"), checkRun("ci", "FAILURE")),
+				withCheckRuns(commitNode("sha1", "msg1"), checkRun("ci", string(success))),
+				withCheckRuns(commitNode("sha2", "msg2"), checkRun("ci", "FAILURE")),
 				withStatusContext(commitNode("sha3", "msg3"), "ci", string(success)),
 			},
 			checks: "ci",
@@ -323,9 +383,41 @@ func TestHydrateCommits(t *testing.T) {
 		if !got[0].AuthoredDate.Equal(authored) {
 			t.Errorf("AuthoredDate = %v, want %v", got[0].AuthoredDate, authored)
 		}
-		// SpecificCheckPassed is never populated by hydrateCommits.
-		if got[0].SpecificCheckPassed {
-			t.Errorf("SpecificCheckPassed = true, want false")
+	})
+
+	t.Run("reports why each requested check did not pass", func(t *testing.T) {
+		node := withWorkflowSuite(
+			withCheckRuns(
+				commitNode("sha1", "msg1"),
+				checkRun("green", string(success)),
+				checkRun("red", "FAILURE"),
+				pendingCheckRun("running"),
+			),
+			"workflow-green", string(success),
+		)
+
+		got := hydrateCommits(newQuery(node), "green,red,running,absent,workflow-green", ",")
+		if len(got) != 1 {
+			t.Fatalf("got %d commits, want 1", len(got))
+		}
+
+		want := []CheckResult{
+			{Name: "green", State: CheckPassed},
+			{Name: "red", State: CheckFailed},
+			{Name: "running", State: CheckPending},
+			{Name: "absent", State: CheckNotFound},
+			{Name: "workflow-green", State: CheckPassed},
+		}
+		if len(got[0].CheckResults) != len(want) {
+			t.Fatalf("got %d results %v, want %d", len(got[0].CheckResults), got[0].CheckResults, len(want))
+		}
+		for i, w := range want {
+			if got[0].CheckResults[i] != w {
+				t.Errorf("result %d = %+v, want %+v", i, got[0].CheckResults[i], w)
+			}
+		}
+		if got[0].StatusSuccess {
+			t.Errorf("StatusSuccess = true, want false")
 		}
 	})
 
@@ -359,6 +451,47 @@ func TestHydrateCommits(t *testing.T) {
 			t.Errorf("Parents = %v, want nil", got[0].Parents)
 		}
 	})
+}
+
+// --- paging over a commit's check data --------------------------------------
+
+// A commit whose check data spans several pages must be judged on all of it. This covers the
+// resolution half of that contract — the part TopUpChecks performs once it has fetched a page —
+// without going near the network: state accumulates across pages and settle() re-publishes it.
+func TestChecksResolvedAcrossPages(t *testing.T) {
+	firstPage := withCheckRuns(commitNode("sha1", "msg1"), checkRun("a", string(success)))
+	firstPage.StatusCheckRollup.Contexts.PageInfo = PageInfo{HasNextPage: true, EndCursor: "cursor1"}
+
+	commits := hydrateCommits(newQuery(firstPage), "a,b", ",")
+	if len(commits) != 1 {
+		t.Fatalf("got %d commits, want 1", len(commits))
+	}
+	c := &commits[0]
+
+	if c.StatusSuccess {
+		t.Errorf("StatusSuccess = true after first page, want false: b has not been seen yet")
+	}
+	if !c.ChecksTruncated() {
+		t.Fatalf("ChecksTruncated() = false, want true: the rollup reported another page")
+	}
+
+	// What TopUpChecks does with the next page it fetches.
+	applyRollupContexts(c.states, []RollupContext{checkRun("b", string(success))})
+	c.settle()
+
+	if !c.StatusSuccess {
+		t.Errorf("StatusSuccess = false after the second page, want true: %+v", c.CheckResults)
+	}
+}
+
+func TestChecksNotTruncatedWhenConnectionsAreComplete(t *testing.T) {
+	commits := hydrateCommits(newQuery(withCheckRuns(commitNode("sha1", "msg1"), checkRun("a", string(success)))), "a", ",")
+	if len(commits) != 1 {
+		t.Fatalf("got %d commits, want 1", len(commits))
+	}
+	if commits[0].ChecksTruncated() {
+		t.Errorf("ChecksTruncated() = true, want false: neither connection reported another page")
+	}
 }
 
 // --- PickFirstParentCommits -------------------------------------------------

--- a/github/manager_test.go
+++ b/github/manager_test.go
@@ -1,0 +1,442 @@
+package github
+
+import (
+	"testing"
+	"time"
+
+	"github.com/shurcooL/githubv4"
+)
+
+// These are characterization tests: they pin the CURRENT behaviour of
+// hydrateCommits and PickFirstParentCommits, defects included. Cases that assert
+// a known defect are marked with a KNOWN DEFECT comment.
+//
+// Not covered here, deliberately: the defect where a required check falls outside
+// checkSuites(first: 20) / checkRuns(first: 25) and is therefore never seen. That is a
+// property of the GraphQL query, not of hydrateCommits — which only ever sees whatever
+// was already fetched, so a fixture holding 21 suites would simply have all 21 read.
+// It is covered instead by the end-to-end verdict baseline in testdata/baseline/.
+
+// success is the only value hydrateCommits/checkRunSet treat as a passing check.
+const success = githubv4.String(githubv4.StatusStateSuccess)
+
+// --- fixture builders -------------------------------------------------------
+
+func newQuery(nodes ...EdgeRootNode) *Query {
+	q := &Query{}
+	for _, n := range nodes {
+		q.Repository.Ref.Target.Commit.History.Edges = append(
+			q.Repository.Ref.Target.Commit.History.Edges,
+			Edge{Node: n},
+		)
+	}
+	return q
+}
+
+func commitNode(sha, message string) EdgeRootNode {
+	return EdgeRootNode{
+		Oid:     githubv4.String(sha),
+		Message: githubv4.String(message),
+	}
+}
+
+// withStatusContext adds a classic commit status to Status.Contexts.
+func withStatusContext(n EdgeRootNode, name, state string) EdgeRootNode {
+	n.Status.Contexts = append(n.Status.Contexts, Context{
+		Context: githubv4.String(name),
+		State:   githubv4.String(state),
+	})
+	return n
+}
+
+func checkRun(name, conclusion string) CheckRunNodes {
+	return CheckRunNodes{
+		Name:       githubv4.String(name),
+		Conclusion: githubv4.String(conclusion),
+	}
+}
+
+// withCheckRunSuite adds a check suite whose WorkflowRun is the zero value, so
+// checkRunSet only looks at its CheckRuns.Nodes.
+func withCheckRunSuite(n EdgeRootNode, runs ...CheckRunNodes) EdgeRootNode {
+	n.CheckSuites.Nodes = append(n.CheckSuites.Nodes, CheckSuiteNode{
+		CheckRuns: CheckRuns{Nodes: runs},
+	})
+	return n
+}
+
+// withWorkflowSuite adds a check suite identified by its workflow name, whose
+// verdict lives in WorkflowRun.CheckSuite.Conclusion.
+func withWorkflowSuite(n EdgeRootNode, workflowName, conclusion string, runs ...CheckRunNodes) EdgeRootNode {
+	n.CheckSuites.Nodes = append(n.CheckSuites.Nodes, CheckSuiteNode{
+		WorkflowRun: WorkflowRun{
+			Workflow:   Workflow{Name: githubv4.String(workflowName)},
+			CheckSuite: CheckSuite{Conclusion: githubv4.String(conclusion)},
+		},
+		CheckRuns: CheckRuns{Nodes: runs},
+	})
+	return n
+}
+
+func withRollup(n EdgeRootNode, state string) EdgeRootNode {
+	n.StatusCheckRollup.State = githubv4.String(state)
+	return n
+}
+
+func withParents(n EdgeRootNode, shaMessagePairs ...string) EdgeRootNode {
+	for i := 0; i < len(shaMessagePairs); i += 2 {
+		n.Parents.Edges = append(n.Parents.Edges, EdgeParent{Node: EdgeNode{
+			Oid:     githubv4.String(shaMessagePairs[i]),
+			Message: githubv4.String(shaMessagePairs[i+1]),
+		}})
+	}
+	return n
+}
+
+// --- hydrateCommits ---------------------------------------------------------
+
+func TestHydrateCommits(t *testing.T) {
+	tests := []struct {
+		name   string
+		nodes  []EdgeRootNode
+		checks string
+		sep    string
+		want   []bool
+	}{
+		{
+			name:   "classic commit status with SUCCESS state passes",
+			nodes:  []EdgeRootNode{withStatusContext(commitNode("sha1", "msg1"), "ci", string(success))},
+			checks: "ci",
+			sep:    ",",
+			want:   []bool{true},
+		},
+		{
+			name:   "check run with SUCCESS conclusion passes",
+			nodes:  []EdgeRootNode{withCheckRunSuite(commitNode("sha1", "msg1"), checkRun("ci", string(success)))},
+			checks: "ci",
+			sep:    ",",
+			want:   []bool{true},
+		},
+		{
+			name:   "workflow name match with SUCCESS check suite conclusion passes",
+			nodes:  []EdgeRootNode{withWorkflowSuite(commitNode("sha1", "msg1"), "ci", string(success))},
+			checks: "ci",
+			sep:    ",",
+			want:   []bool{true},
+		},
+		{
+			// KNOWN DEFECT (double count): the requested name is found twice —
+			// once as a classic status, once as a check run — so checksPassed
+			// reaches 2 while numChecks is 1, and the `checksPassed == numChecks`
+			// gate rejects a commit whose check actually succeeded. A later step
+			// will intentionally flip this expectation to true.
+			name: "same name as both classic status and check run is double counted and fails",
+			nodes: []EdgeRootNode{withCheckRunSuite(
+				withStatusContext(commitNode("sha1", "msg1"), "ci", string(success)),
+				checkRun("ci", string(success)),
+			)},
+			checks: "ci",
+			sep:    ",",
+			want:   []bool{false},
+		},
+		{
+			// KNOWN DEFECT (double count): re-runs produce several check runs with
+			// the same name; each SUCCESS increments the counter. A later step will
+			// intentionally flip this expectation to true.
+			name: "duplicate successful check runs in one suite are double counted and fail",
+			nodes: []EdgeRootNode{withCheckRunSuite(
+				commitNode("sha1", "msg1"),
+				checkRun("ci", string(success)),
+				checkRun("ci", string(success)),
+			)},
+			checks: "ci",
+			sep:    ",",
+			want:   []bool{false},
+		},
+		{
+			// KNOWN DEFECT (double count): same as above, across two suites.
+			// A later step will intentionally flip this expectation to true.
+			name: "duplicate successful check runs across suites are double counted and fail",
+			nodes: []EdgeRootNode{withCheckRunSuite(
+				withCheckRunSuite(commitNode("sha1", "msg1"), checkRun("ci", string(success))),
+				checkRun("ci", string(success)),
+			)},
+			checks: "ci",
+			sep:    ",",
+			want:   []bool{false},
+		},
+		{
+			// A missing check is indistinguishable from a failing one.
+			name: "requested name absent from every source fails",
+			nodes: []EdgeRootNode{withCheckRunSuite(
+				withStatusContext(commitNode("sha1", "msg1"), "other-status", string(success)),
+				checkRun("other-run", string(success)),
+			)},
+			checks: "ci",
+			sep:    ",",
+			want:   []bool{false},
+		},
+		{
+			name:   "check run with FAILURE conclusion fails",
+			nodes:  []EdgeRootNode{withCheckRunSuite(commitNode("sha1", "msg1"), checkRun("ci", "FAILURE"))},
+			checks: "ci",
+			sep:    ",",
+			want:   []bool{false},
+		},
+		{
+			name:   "check run with NEUTRAL conclusion fails",
+			nodes:  []EdgeRootNode{withCheckRunSuite(commitNode("sha1", "msg1"), checkRun("ci", "NEUTRAL"))},
+			checks: "ci",
+			sep:    ",",
+			want:   []bool{false},
+		},
+		{
+			name:   "check run with SKIPPED conclusion fails",
+			nodes:  []EdgeRootNode{withCheckRunSuite(commitNode("sha1", "msg1"), checkRun("ci", "SKIPPED"))},
+			checks: "ci",
+			sep:    ",",
+			want:   []bool{false},
+		},
+		{
+			name:   "classic commit status with FAILURE state fails",
+			nodes:  []EdgeRootNode{withStatusContext(commitNode("sha1", "msg1"), "ci", "FAILURE")},
+			checks: "ci",
+			sep:    ",",
+			want:   []bool{false},
+		},
+		{
+			// With no requested names the rollup state decides. Note the counting
+			// block still runs first (strings.Split("", ",") yields [""], so
+			// numChecks is 1) but its verdict is unconditionally overwritten here.
+			name:   "empty checks names uses SUCCESS rollup state",
+			nodes:  []EdgeRootNode{withRollup(commitNode("sha1", "msg1"), string(success))},
+			checks: "",
+			sep:    ",",
+			want:   []bool{true},
+		},
+		{
+			name:   "empty checks names uses FAILURE rollup state",
+			nodes:  []EdgeRootNode{withRollup(commitNode("sha1", "msg1"), "FAILURE")},
+			checks: "",
+			sep:    ",",
+			want:   []bool{false},
+		},
+		{
+			// The rollup branch overwrites the counting result, so even a commit
+			// whose checks would have counted as passing follows the rollup.
+			name: "empty checks names ignores passing checks and follows the rollup",
+			nodes: []EdgeRootNode{withRollup(
+				withStatusContext(commitNode("sha1", "msg1"), "", string(success)),
+				"FAILURE",
+			)},
+			checks: "",
+			sep:    ",",
+			want:   []bool{false},
+		},
+		{
+			name: "two requested names with only one passing fails",
+			nodes: []EdgeRootNode{withCheckRunSuite(
+				commitNode("sha1", "msg1"),
+				checkRun("a", string(success)),
+				checkRun("b", "FAILURE"),
+			)},
+			checks: "a,b",
+			sep:    ",",
+			want:   []bool{false},
+		},
+		{
+			name: "two requested names each passing once via a different source succeeds",
+			nodes: []EdgeRootNode{withCheckRunSuite(
+				withStatusContext(commitNode("sha1", "msg1"), "a", string(success)),
+				checkRun("b", string(success)),
+			)},
+			checks: "a,b",
+			sep:    ",",
+			want:   []bool{true},
+		},
+		{
+			name: "custom separator splits the requested names",
+			nodes: []EdgeRootNode{withCheckRunSuite(
+				withStatusContext(commitNode("sha1", "msg1"), "a", string(success)),
+				checkRun("b", string(success)),
+			)},
+			checks: "a|b",
+			sep:    "|",
+			want:   []bool{true},
+		},
+		{
+			name: "each commit in the history is evaluated independently and in order",
+			nodes: []EdgeRootNode{
+				withCheckRunSuite(commitNode("sha1", "msg1"), checkRun("ci", string(success))),
+				withCheckRunSuite(commitNode("sha2", "msg2"), checkRun("ci", "FAILURE")),
+				withStatusContext(commitNode("sha3", "msg3"), "ci", string(success)),
+			},
+			checks: "ci",
+			sep:    ",",
+			want:   []bool{true, false, true},
+		},
+		{
+			name:   "empty history returns no commits",
+			nodes:  nil,
+			checks: "ci",
+			sep:    ",",
+			want:   nil,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			got := hydrateCommits(newQuery(tt.nodes...), tt.checks, tt.sep)
+
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %d commits, want %d", len(got), len(tt.want))
+			}
+			for i, want := range tt.want {
+				if got[i].StatusSuccess != want {
+					t.Errorf("commit %d (%s): StatusSuccess = %t, want %t",
+						i, got[i].SHA, got[i].StatusSuccess, want)
+				}
+			}
+		})
+	}
+
+	t.Run("maps commit fields", func(t *testing.T) {
+		authored := time.Date(2021, time.June, 1, 12, 30, 0, 0, time.UTC)
+		node := commitNode("abc123", "feat: something")
+		node.AuthoredDate = githubv4.DateTime{Time: authored}
+		node.Author = Author{Name: "Ada Lovelace"}
+
+		got := hydrateCommits(newQuery(node), "ci", ",")
+		if len(got) != 1 {
+			t.Fatalf("got %d commits, want 1", len(got))
+		}
+		if got[0].SHA != "abc123" {
+			t.Errorf("SHA = %q, want %q", got[0].SHA, "abc123")
+		}
+		if got[0].Message != "feat: something" {
+			t.Errorf("Message = %q, want %q", got[0].Message, "feat: something")
+		}
+		if got[0].AuthorName != "Ada Lovelace" {
+			t.Errorf("AuthorName = %q, want %q", got[0].AuthorName, "Ada Lovelace")
+		}
+		if !got[0].AuthoredDate.Equal(authored) {
+			t.Errorf("AuthoredDate = %v, want %v", got[0].AuthoredDate, authored)
+		}
+		// SpecificCheckPassed is never populated by hydrateCommits.
+		if got[0].SpecificCheckPassed {
+			t.Errorf("SpecificCheckPassed = true, want false")
+		}
+	})
+
+	t.Run("maps parents", func(t *testing.T) {
+		node := withParents(commitNode("head", "head msg"), "p1", "parent one", "p2", "parent two")
+
+		got := hydrateCommits(newQuery(node), "ci", ",")
+		if len(got) != 1 {
+			t.Fatalf("got %d commits, want 1", len(got))
+		}
+		parents := got[0].Parents
+		if len(parents) != 2 {
+			t.Fatalf("got %d parents, want 2", len(parents))
+		}
+		if parents[0].SHA != "p1" || parents[0].Message != "parent one" {
+			t.Errorf("parent 0 = {%q, %q}, want {%q, %q}",
+				parents[0].SHA, parents[0].Message, "p1", "parent one")
+		}
+		if parents[1].SHA != "p2" || parents[1].Message != "parent two" {
+			t.Errorf("parent 1 = {%q, %q}, want {%q, %q}",
+				parents[1].SHA, parents[1].Message, "p2", "parent two")
+		}
+	})
+
+	t.Run("commit with no parents has nil parents", func(t *testing.T) {
+		got := hydrateCommits(newQuery(commitNode("head", "head msg")), "ci", ",")
+		if len(got) != 1 {
+			t.Fatalf("got %d commits, want 1", len(got))
+		}
+		if got[0].Parents != nil {
+			t.Errorf("Parents = %v, want nil", got[0].Parents)
+		}
+	})
+}
+
+// --- PickFirstParentCommits -------------------------------------------------
+
+func TestPickFirstParentCommits(t *testing.T) {
+	tests := []struct {
+		name  string
+		input []Commit
+		want  []string
+	}{
+		{
+			name:  "empty input returns nothing",
+			input: nil,
+			want:  nil,
+		},
+		{
+			name:  "single commit without parents returns just that commit",
+			input: []Commit{{SHA: "head"}},
+			want:  []string{"head"},
+		},
+		{
+			name: "linear chain is walked from HEAD down",
+			input: []Commit{
+				{SHA: "head", Parents: []Commit{{SHA: "a"}}},
+				{SHA: "a", Parents: []Commit{{SHA: "b"}}},
+				{SHA: "b"},
+			},
+			want: []string{"head", "a", "b"},
+		},
+		{
+			name: "walk stops when a parent is missing from the list",
+			input: []Commit{
+				{SHA: "head", Parents: []Commit{{SHA: "a"}}},
+				{SHA: "a", Parents: []Commit{{SHA: "beyond-the-page"}}},
+			},
+			want: []string{"head", "a"},
+		},
+		{
+			name: "only the first parent of a merge commit is followed",
+			input: []Commit{
+				{SHA: "merge", Parents: []Commit{{SHA: "a"}, {SHA: "b"}}},
+				{SHA: "a"},
+				{SHA: "b"},
+			},
+			want: []string{"merge", "a"},
+		},
+		{
+			name: "commits unreachable through first parents are dropped",
+			input: []Commit{
+				{SHA: "head", Parents: []Commit{{SHA: "a"}}},
+				{SHA: "side", Parents: []Commit{{SHA: "a"}}},
+				{SHA: "a"},
+			},
+			want: []string{"head", "a"},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			got := PickFirstParentCommits(tt.input)
+
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %d commits %v, want %d %v", len(got), shas(got), len(tt.want), tt.want)
+			}
+			for i, want := range tt.want {
+				if got[i].SHA != want {
+					t.Errorf("commit %d: SHA = %q, want %q", i, got[i].SHA, want)
+				}
+			}
+		})
+	}
+}
+
+func shas(commits []Commit) []string {
+	out := make([]string, 0, len(commits))
+	for _, c := range commits {
+		out = append(out, c.SHA)
+	}
+	return out
+}

--- a/github/types.go
+++ b/github/types.go
@@ -2,19 +2,6 @@ package github
 
 import "github.com/shurcooL/githubv4"
 
-// CheckRunNodes represents the checkRun status of the Nodes
-type CheckRunNodes struct {
-	Name       githubv4.String
-	Status     githubv4.String
-	Title      githubv4.String
-	Conclusion githubv4.String
-}
-
-// CheckRuns represents the check run of an array of Nodes
-type CheckRuns struct {
-	Nodes []CheckRunNodes
-}
-
 // Workflow represents the information of the Github Workflow
 type Workflow struct {
 	Name githubv4.String
@@ -31,15 +18,27 @@ type WorkflowRun struct {
 	CheckSuite CheckSuite
 }
 
-// CheckSuiteNode represents the information about the check suite information of the Node
+// CheckSuiteNode represents the information about the check suite information of the Node.
+//
+// Deliberately does not select the nested checkRuns connection. Check runs are read from
+// statusCheckRollup.contexts instead, which returns them as a flat, de-duplicated list; nesting
+// checkRuns under checkSuites multiplied the query's node count by suites × runs per commit and
+// made whether a check was seen at all depend on check-suite ordering.
 type CheckSuiteNode struct {
 	WorkflowRun WorkflowRun
-	CheckRuns   CheckRuns `graphql:"checkRuns(first: 25)"`
 }
 
 // CheckSuites represents the information about the check suite of a slice of Nodes
 type CheckSuites struct {
-	Nodes []CheckSuiteNode
+	TotalCount githubv4.Int
+	PageInfo   PageInfo
+	Nodes      []CheckSuiteNode
+}
+
+// PageInfo carries the cursor of a connection so remaining pages can be fetched on demand.
+type PageInfo struct {
+	HasNextPage githubv4.Boolean
+	EndCursor   githubv4.String
 }
 
 // Context represents the information about the Context
@@ -48,7 +47,10 @@ type Context struct {
 	State   githubv4.String
 }
 
-// NodeStatus represents the information about a slice of Contexts
+// NodeStatus represents the information about a slice of Contexts.
+//
+// Commit.status.contexts is a plain list rather than a connection, so this is always the complete
+// set of classic commit statuses — there is nothing to paginate.
 type NodeStatus struct {
 	Contexts []Context
 }
@@ -64,15 +66,42 @@ type EdgeParent struct {
 	Node EdgeNode
 }
 
-// StatusCheckRollupContexts represents the information about the status check of roullup contexts
+// RollupStatusContext is the StatusContext member of the statusCheckRollup contexts union: a
+// classic commit status.
+type RollupStatusContext struct {
+	Context githubv4.String
+	State   githubv4.String
+}
+
+// RollupCheckRun is the CheckRun member of the statusCheckRollup contexts union.
+type RollupCheckRun struct {
+	Name       githubv4.String
+	Status     githubv4.String
+	Conclusion githubv4.String
+}
+
+// RollupContext is one entry of statusCheckRollup.contexts, a union of StatusContext and CheckRun.
+// Typename says which member is populated.
+type RollupContext struct {
+	Typename      githubv4.String     `graphql:"__typename"`
+	StatusContext RollupStatusContext `graphql:"... on StatusContext"`
+	CheckRun      RollupCheckRun      `graphql:"... on CheckRun"`
+}
+
+// StatusCheckRollupContexts represents the information about the status check of rollup contexts.
+//
+// GitHub returns the latest run per check name here, so re-runs of the same check collapse to a
+// single entry instead of appearing once per attempt.
 type StatusCheckRollupContexts struct {
 	TotalCount githubv4.Int
+	PageInfo   PageInfo
+	Nodes      []RollupContext
 }
 
 // StatusCheckRollup represents the information about the status check of rollup
 type StatusCheckRollup struct {
 	State    githubv4.String
-	Contexts StatusCheckRollupContexts `graphql:"contexts(first: $parentsNumber)"`
+	Contexts StatusCheckRollupContexts `graphql:"contexts(first: $contextsNumber)"`
 }
 
 // Author represents the information about the commit author
@@ -93,7 +122,7 @@ type EdgeRootNode struct {
 	AuthoredDate      githubv4.DateTime
 	Author            Author
 	StatusCheckRollup StatusCheckRollup
-	CheckSuites       CheckSuites `graphql:"checkSuites(first: 20)"`
+	CheckSuites       CheckSuites `graphql:"checkSuites(first: $checkSuitesNumber)"`
 	Status            NodeStatus
 }
 
@@ -130,4 +159,29 @@ type Repository struct {
 // Query represents the information obtained in a Github Query
 type Query struct {
 	Repository Repository `graphql:"repository(owner: $owner, name: $name)"`
+}
+
+// CommitSuitesQuery fetches one further page of a single commit's check suites. Used when the first
+// page did not cover every suite and the commit has not yet satisfied its checks.
+type CommitSuitesQuery struct {
+	Repository struct {
+		Object struct {
+			Commit struct {
+				CheckSuites CheckSuites `graphql:"checkSuites(first: $checkSuitesNumber, after: $suitesAfter)"`
+			} `graphql:"... on Commit"`
+		} `graphql:"object(oid: $oid)"`
+	} `graphql:"repository(owner: $owner, name: $name)"`
+}
+
+// CommitContextsQuery fetches one further page of a single commit's status-check rollup contexts.
+type CommitContextsQuery struct {
+	Repository struct {
+		Object struct {
+			Commit struct {
+				StatusCheckRollup struct {
+					Contexts StatusCheckRollupContexts `graphql:"contexts(first: $contextsNumber, after: $contextsAfter)"`
+				}
+			} `graphql:"... on Commit"`
+		} `graphql:"object(oid: $oid)"`
+	} `graphql:"repository(owner: $owner, name: $name)"`
 }

--- a/manager/flow-manager.go
+++ b/manager/flow-manager.go
@@ -18,20 +18,20 @@ func checkGithubToken(githubToken string) error {
 }
 
 // Manage will do the necessary actions to move the head from one branch to another
-func Manage(githubToken, owner, repo, sourceBranch, destinationBranch, expression string, specificChecksNames string, sep string, lastCommitsNumber int, force, dryRun bool) ([]EvaluationResult, error) {
+func Manage(githubToken, owner, repo, sourceBranch, destinationBranch, expression string, specificChecksNames string, sep string, lastCommitsNumber int, contextsNumber, checkSuitesNumber int, force, dryRun bool) ([]EvaluationResult, error) {
 	err := checkGithubToken(githubToken)
 	if err != nil {
 		return nil, err
 	}
 	parsedExpression := expr.MustParse(expression)
 	gm := github.New(githubToken)
-	commits, err := gm.GetCommits(owner, repo, sourceBranch, lastCommitsNumber, specificChecksNames, sep)
+	commits, err := gm.GetCommits(owner, repo, sourceBranch, lastCommitsNumber, specificChecksNames, sep, contextsNumber, checkSuitesNumber)
 	if nil != err {
 		return nil, err
 	}
 	firstParentCommits := github.PickFirstParentCommits(commits)
 
-	destinationCommits, err := gm.GetCommits(owner, repo, destinationBranch, 1, specificChecksNames, sep)
+	destinationCommits, err := gm.GetCommits(owner, repo, destinationBranch, 1, specificChecksNames, sep, contextsNumber, checkSuitesNumber)
 	if nil != err {
 		return nil, err
 	}
@@ -43,6 +43,15 @@ func Manage(githubToken, owner, repo, sourceBranch, destinationBranch, expressio
 		if destinationCommits[0].SHA == commit.SHA {
 			fmt.Println("COMMIT ID: " + commit.SHA + " IS ALREADY IN " + destinationBranch + " branch. EXITING THE PROCESS WITHOUT ANY ACTION.")
 			return evaluationResultList, nil
+		}
+
+		// The first page of check data may not have covered every check. Only worth paying for
+		// when the commit has not already passed — and only for commits actually examined, which
+		// is why this sits here rather than in GetCommits.
+		if !commit.StatusSuccess && commit.ChecksTruncated() {
+			if err := gm.TopUpChecks(owner, repo, &commit); err != nil {
+				return nil, err
+			}
 		}
 
 		evalContext := datasource.NewContextSimpleNative(map[string]interface{}{

--- a/testdata/baseline/README.md
+++ b/testdata/baseline/README.md
@@ -1,0 +1,42 @@
+# Promotion-verdict baseline
+
+A regression net for changes to check evaluation. It records, for a set of real repositories, the
+verdict this binary reaches for every commit it examines — then lets you re-record after a change
+and diff.
+
+It exists because the failure mode in this area is silent. When a required check is not found, or is
+found more times than expected, the commit simply fails evaluation and the CLI still exits 0. Unit
+tests cover the evaluation logic (`github/manager_test.go`), but they cannot catch a regression in
+the GraphQL query itself — a check that is no longer fetched looks exactly like a check that failed.
+Only running against real repositories catches that.
+
+## Usage
+
+```sh
+cp consumers.tsv.example consumers.tsv   # then edit: your repos, your real status_check_names
+./record.sh /path/to/known-good-gfm  before/     # e.g. a binary from the latest release
+# ... make your change, build a new binary ...
+./record.sh ./gfm-new                 after/
+diff -ru before/ after/
+```
+
+Every run is `--dry-run` and uses an expression that can never be true, so no branch head is ever
+moved and no commit is ever promoted.
+
+Read `consumers.tsv.example` before filling in `consumers.tsv` — the choice of `destination` is the
+one non-obvious part, and getting it wrong silently produces empty recordings.
+
+## Reading a diff
+
+The column that matters is `IS_STATUS_SUCCESS`: it is computed purely from the requested
+`status_check_names`, so it isolates check evaluation from everything else.
+
+A diff is not automatically a regression. These recordings read live CI state, so a repository whose
+CI moved between the two runs will differ for unrelated reasons — that is what the SHAs in each file
+are for. If a repository moved, re-record it; do not reason about the diff. What matters is that
+every remaining difference is one you intended and can name.
+
+## Why this is not committed
+
+`consumers.tsv` and the output directories are gitignored. Recorded output embeds commit messages,
+author names and branch names; for private repositories none of that belongs in a public repo.

--- a/testdata/baseline/consumers.tsv.example
+++ b/testdata/baseline/consumers.tsv.example
@@ -1,0 +1,23 @@
+# Copy to consumers.tsv (gitignored) and fill in with your own repos.
+#
+# One row per repository whose promotion verdict you want to pin, tab-separated:
+#
+#   repo<TAB>source<TAB>destination<TAB>status_check_names
+#
+# `status_check_names` should be exactly what you pass to github-flow-manager in production,
+# so the baseline reflects real configuration rather than a guess.
+#
+# `destination` should NOT be your production destination branch. If source and destination
+# already point at the same commit — the normal state right after a promotion — GFM prints
+# "IS ALREADY IN <branch> branch" and exits before evaluating a single check, so the recording
+# captures nothing. Pick instead any branch that is *not* an ancestor of the source branch
+# (an old feature branch works): GFM then evaluates the whole --commits-number window. Combined
+# with the unsatisfiable expression record.sh uses, nothing is ever promoted.
+#
+# Verify a row is useful by checking its output has as many commit rows as --commits-number.
+#
+# consumers.tsv is gitignored on purpose: recorded output embeds commit messages, author names
+# and branch names, which for private repositories must not be committed to a public repo.
+
+example-app	develop	some-old-feature-branch	Continuous Integration
+other-app	develop	some-old-feature-branch	unit-tests,publish-image / publish-image-example

--- a/testdata/baseline/record.sh
+++ b/testdata/baseline/record.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Record the check-evaluation verdict this binary produces for every real consumer repo.
+#
+# The characterization target is the IS_STATUS_SUCCESS column: it is computed purely by
+# hydrateCommits from the requested status_check_names, independent of the expression. So we run
+# with an expression that can never be true, which means:
+#   - no commit ever "passes", so the promotion branch is never taken (belt to --dry-run's braces)
+#   - the loop is never cut short by a success, so every examined commit appears in the table
+# Combined with the non-ancestor probe destinations in consumers.tsv, this prints a full table of
+# per-commit verdicts, which is exactly what must not change across a refactor.
+#
+#   ./record.sh <path-to-github-flow-manager-binary> <output-dir>
+#
+# Compare a refactor against the recorded baseline:
+#   ./record.sh ./gfm-new /tmp/out-new && diff -ru testdata/baseline/v1.1.10 /tmp/out-new
+#
+# The verdict depends on live GitHub CI state, so a repo whose CI moved between the two runs will
+# differ for reasons unrelated to the code. Each output records the SHAs it saw so drift is visible
+# rather than silent — re-record a moved repo, don't explain the diff away.
+set -uo pipefail
+
+BIN="${1:?usage: record.sh <binary> <output-dir>}"
+OUT="${2:?usage: record.sh <binary> <output-dir>}"
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COMMITS="${COMMITS:-25}" # match whatever your promote workflow passes as --commits-number
+
+# Deliberately unsatisfiable: see header.
+EXPRESSION='Message contains "___gfm_baseline_never_match___"'
+
+: "${GITHUB_TOKEN:="$(gh auth token 2>/dev/null)"}"
+if [ -z "$GITHUB_TOKEN" ]; then
+  echo "GITHUB_TOKEN unset and 'gh auth token' produced nothing" >&2
+  exit 1
+fi
+export GITHUB_TOKEN
+
+mkdir -p "$OUT"
+
+while IFS=$'\t' read -r repo source dest checks; do
+  case "$repo" in '' | '#'*) continue ;; esac
+
+  echo "recording $repo ..." >&2
+  {
+    echo "# repo=$repo source=$source destination=$dest commits=$COMMITS"
+    echo "# expression=$EXPRESSION"
+    echo "# status_check_names=$checks"
+    echo "#"
+    "$BIN" DocPlanner "$repo" "$source" "$dest" "$EXPRESSION" "$checks" \
+      -c "$COMMITS" --dry-run --verbose 2>&1
+    echo "# exit=$?"
+  } >"$OUT/$repo.txt"
+done <"$HERE/consumers.tsv"
+
+echo "wrote $(find "$OUT" -name '*.txt' | wc -l | tr -d ' ') files to $OUT" >&2


### PR DESCRIPTION
Closes #39.

Consumer repository names, check names and commit SHAs are deliberately generic below: this repository is public, the repositories that consume it are not. The concrete identifiers behind each measurement are available internally.

## The measurements that shaped this

PR #33 widened `checkSuites`/`checkRuns` to 100 and #35 reverted it on cost grounds. Both were reasoning about the right risk with the wrong numbers, so I measured before touching anything (`rateLimit(dryRun: true)`, against a large internal monorepo, at `-c 25` — what the shared promote workflow passes):

| query shape | commits | nodeCount | cost |
|---|---|---|---|
| before (`suites 20 × runs 25`) | 25 | 13,075 | **6** |
| before | 100 | 52,300 | **23** |
| PR #33 (`100 × 100`) | 25 | 252,575 | **26** |
| PR #33 (`100 × 100`) | 100 | — | **`MAX_NODE_LIMIT_EXCEEDED`** |
| this PR | 25 | 5,050 | **1** |
| this PR | 100 | 20,200 | **3** |

- #35's figures (131 → 2,526 points) were `nodeCount/100`, not the cost GitHub charges. The real increase was 6 → 26, so ~4.3×, not ~20×.
- The increase was still worth reverting: the token is a **GitHub App installation token shared by every repository** using the shared reusable promote workflow, so that budget is org-wide, not per-repo. Hitting limits is entirely consistent with the arithmetic.
- What should have blocked #33 outright is the last row: at `--commits-number 100`, the CLI's own default, that shape is rejected before it runs.

This PR goes the other way — **1 point at `-c 25`, 6× cheaper than today** — while seeing more than #33 did.

## What was actually broken

**Counting, and it is live.** `checksPassed` was incremented per matching check and compared with `==` against the number of requested names, so finding a name twice pushed the count past the target and rejected a commit whose checks had passed. One consumer repository publishes its aggregate required check as *both* a classic commit status and a check run on the same commit. It promotes today only because the check run falls outside the fetched window:

```
classicMatches=1  checkRunMatches=0  checksPassed=1  numChecks=1  → promotes
```

Widen the window and that becomes `2 == 1` → false → promotion silently stops. **Any** coverage increase, #33's included, had to land together with the counting fix. Names now resolve to a state instead of a tally.

**Coverage.** Check runs now come from `statusCheckRollup.contexts`, which is flat and de-duplicated by GitHub, so ordering across suites stops deciding whether a check is seen. Dropping the nested `checkRuns` connection is where the cost win comes from. I checked whether the rollup could replace `checkSuites` entirely (`CheckRun.checkSuite.workflowRun.workflow.name` costs 0 extra nodes) — it cannot: on a commit with over 130 check suites it yields 4 of 6 SUCCESS workflow names, so both connections stay.

**The 100-per-page ceiling.** Both connections cap at 100 and real repositories exceed it. Remaining pages are fetched by `TopUpChecks` from the evaluation loop, not from hydration — that loop already stops at the first passing commit, so the usual case costs no extra requests. Proven by asymmetry: at `--check-suites-number 5` the first page contains no workflow runs at all, yet a required check that resolves only via a workflow name still comes back ✔.

## Two things I did not expect

**Defect 2 in the issue has no functional impact.** The loop reads `Commit.status.contexts`, which is a plain LIST in GitHub's schema — no `first`, never truncated. The `contexts(first: $parentsNumber)` connection is on `statusCheckRollup` and selected only `totalCount`, which is read nowhere. It was dead weight, not an under-count. It now has a real purpose and its own variable.

**Defaults are 50, not 100.** A 100/100 first page makes GitHub exceed its own execution limit on the heaviest repository and return `504` — cost is not the only ceiling. At 50/50 the new query fails in exactly the same places the old one does (on that repository both fail above `-c 25` and both succeed at `-c 25`, which is what the shared workflow passes), so this is not a new limit. `GetCommits` now names the knobs to turn when it happens.

## Diagnosability

The issue asked for not-found to read differently from found-but-failing. It does now:

```
UNSATISFIED STATUS CHECKS ("not found" means no status, check run or workflow of that name exists on the commit):
  a1b2c3d4  failed: some-check
  e5f6a7b8  not found: some-other-check
```

That second line is not hypothetical — one consumer requests a check name that exists nowhere on its commits. No truncation involved, the name is simply stale, and until now that was indistinguishable from a failing build.

## Verification

- First commit is characterization tests only, green against unmodified logic, asserting the defects as they were. The port flips exactly three assertions, each marked `WAS A DEFECT, NOW FIXED`; every other expectation is unchanged.
- `go build`, `go vet`, `go test ./...`, `gofmt -l`, `golangci-lint` (v1.44.2, as CI) all clean. A `go test ./...` job is added — CI previously ran lint only.
- **Re-ran all 11 consumer repositories before and after** (`testdata/baseline/`, always `--dry-run` and with an unsatisfiable expression, so nothing is ever promoted): **10 byte-identical verdicts across 244 commits, 1 differing only by a commit that landed between runs while agreeing on all 24 shared commits, 0 verdict changes.**

The baseline harness is tracked but its repository list and recordings are gitignored — recorded output embeds commit messages, author names and branch names, and this repository is public.

## Not changed

One consumer's required check currently concludes `NEUTRAL` on recent commits, and `NEUTRAL` does not satisfy a check. This PR does not change which conclusions count as passing.

No tag. The shared reusable workflow defaults to the `latest` image tag, so releasing reaches every repository at once.
