### PR TITLE
fix: read check runs from the status rollup and page past the first 100

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,9 @@
 
 # Generated binary files
 bin
+
+# Promotion-verdict baselines (see testdata/baseline/README.md). Recorded output embeds commit
+# messages, author names and branch names; for private repositories that must not land in this
+# public repo. The harness is tracked, the repo list and the recordings are not.
+testdata/baseline/consumers.tsv
+testdata/baseline/*/

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
   - [Help](#help)
   - [Example](#example)
   - [How specific check names are evaluated](#how-specific-check-names-are-evaluated)
+  - [Fetching a commit's checks](#fetching-a-commits-checks)
   - [Pre commit](#pre-commit)
   - [Expressions](#expressions)
     - [Available variables](#available-variables)
@@ -41,6 +42,9 @@ Flags:
       --accept-skipped-checks
                               Accept a required check GitHub reports as SKIPPED as satisfied
   -c, --commits-number int    Number of commits to get under evaluation (>0, <=100) (default 100)
+      --check-suites-number int
+                              Check suites to fetch per commit in the first page (>0, <=100) (default 50)
+      --contexts-number int   Status checks to fetch per commit in the first page (>0, <=100) (default 50)
   -d, --dry-run               Don't modify repository
   -f, --force                 Use the force Luke... - Changes branch HEAD with force
   -t, --github-token string   GitHub token (can be passed also as GITHUB_TOKEN env variable
@@ -102,6 +106,21 @@ status check rollup for the commit, unchanged.
 With `--verbose`, any commit held back by its required checks is listed under the
 table with one line per required name, so a stalled promotion can be diagnosed
 from the job log.
+
+## Fetching a commit's checks
+
+GitHub returns a commit's status checks and check suites as connections capped at **100 entries per
+page**, and repositories with a lot of CI exceed that. `--contexts-number` and
+`--check-suites-number` size only the *first* page: anything beyond it is fetched on demand, per
+commit, and only for commits that are examined and have not already been satisfied. So these flags
+trade the number of requests against the size of each one — lowering them does not cause a check to
+be missed, and a commit is never judged on a partial view.
+
+They default to 50 rather than the maximum because the ceiling is not only rate limit but GitHub's
+own query execution time: on a repository with enough CI, a first page of 100 × 100 comes back as
+`502` or `504` instead of an answer. The server-side work is roughly
+`--commits-number × (--contexts-number + --check-suites-number)`, so lowering any of the three helps.
+Lower `--commits-number` last, since unlike the other two it changes which commits are considered.
 
 ## Pre commit
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -14,6 +14,8 @@ import (
 
 var (
 	commitsNumber       *int
+	contextsNumber      *int
+	checkSuitesNumber   *int
 	githubToken         *string
 	force               *bool
 	verbose             *bool
@@ -69,7 +71,7 @@ If a SPECIFIC_COMMIT_CHECK_NAME is specified, the StatusSuccess will be calculat
 			*githubToken = os.Getenv("GITHUB_TOKEN")
 		}
 
-		results, err := flow_manager.Manage(*githubToken, owner, repo, sourceBranch, destinationBranch, expression, specificChecksNames, *separator, *acceptSkippedChecks, *commitsNumber, *force, *dryRun)
+		results, err := flow_manager.Manage(*githubToken, owner, repo, sourceBranch, destinationBranch, expression, specificChecksNames, *separator, *acceptSkippedChecks, *contextsNumber, *checkSuitesNumber, *commitsNumber, *force, *dryRun)
 		if err != nil {
 			fmt.Println(err.Error())
 			os.Exit(1)
@@ -143,5 +145,7 @@ func init() {
 	verbose = rootCmd.Flags().BoolP("verbose", "v", false, "Print table with commits evaluation status")
 	dryRun = rootCmd.Flags().BoolP("dry-run", "d", false, "Don't modify repository")
 	separator = rootCmd.Flags().StringP("separator", "s", ",", "Set string separator of status checks")
+	contextsNumber = rootCmd.Flags().Int("contexts-number", 50, "Status checks to fetch per commit in the first page (>0, <=100). Later pages are fetched on demand, so this trades requests against page size rather than dropping checks")
+	checkSuitesNumber = rootCmd.Flags().Int("check-suites-number", 50, "Check suites to fetch per commit in the first page (>0, <=100). Same trade-off as --contexts-number")
 	acceptSkippedChecks = rootCmd.Flags().Bool("accept-skipped-checks", false, "Accept a required check GitHub reports as SKIPPED as satisfied (off by default: only SUCCESS satisfies a required check)")
 }

--- a/github/checks.go
+++ b/github/checks.go
@@ -32,6 +32,28 @@ type checkResult struct {
 // noVerdictYet is shown for a result GitHub has not concluded yet.
 const noVerdictYet = "NO_CONCLUSION_YET"
 
+// checkSources is everything read for one commit that can carry a required check name.
+//
+// It is a struct rather than the query Edge because two of the three sources are paginated
+// connections: GitHub caps checkSuites and statusCheckRollup.contexts at 100 entries per page, and
+// repositories with a lot of CI exceed that. Later pages append to these slices and the commit is
+// evaluated again, so a verdict is never reached on a partial view.
+type checkSources struct {
+	statuses       []Context
+	rollupContexts []RollupContext
+	suites         []CheckSuiteNode
+}
+
+// sourcesFromEdge pulls the three places a required check name can be reported from one commit of
+// the history query.
+func sourcesFromEdge(edge Edge) checkSources {
+	return checkSources{
+		statuses:       edge.Node.Status.Contexts,
+		rollupContexts: edge.Node.StatusCheckRollup.Contexts.Nodes,
+		suites:         edge.Node.CheckSuites.Nodes,
+	}
+}
+
 // splitCheckNames splits the required check names supplied on the command line,
 // dropping whitespace and empty entries so that a stray separator (`a,b,` or
 // `a, b`) cannot silently add a name that can never be satisfied.
@@ -83,7 +105,7 @@ func classifyConclusion(conclusion githubv4.String, acceptSkipped bool) checkOut
 
 // classifyCheckRun classifies a single check run. Its status wins over its
 // conclusion: a run that has not completed cannot have a trustworthy verdict.
-func classifyCheckRun(checkRun CheckRunNodes, acceptSkipped bool) checkResult {
+func classifyCheckRun(checkRun RollupCheckRun, acceptSkipped bool) checkResult {
 	if checkRun.Status != "" && githubv4.CheckStatusState(checkRun.Status) != githubv4.CheckStatusStateCompleted {
 		return checkResult{outcome: outcomePending, verdict: string(checkRun.Status)}
 	}
@@ -126,33 +148,44 @@ func classifyStatusContext(ctx Context) checkResult {
 // all three are searched. One name legitimately matching several results is
 // normal: while a merge queue is active, a commit is built twice, once for the
 // queue run and once for the push run, and both report the same workflow name.
-func collectResults(name string, edge Edge, acceptSkipped bool) []checkResult {
+func collectResults(name string, sources checkSources, acceptSkipped bool) []checkResult {
 	var results []checkResult
 
 	// A commit status set directly on the commit (the classic statuses API).
-	for _, ctx := range edge.Node.Status.Contexts {
+	for _, ctx := range sources.statuses {
 		if githubv4.String(name) == ctx.Context {
 			results = append(results, classifyStatusContext(ctx))
 		}
 	}
 
-	for _, checkSuite := range edge.Node.CheckSuites.Nodes {
-		// The required name can be the name of the workflow itself, in which
-		// case the suite's conclusion is the workflow run's verdict.
+	// The status-check rollup, which carries both check runs and commit statuses as a single flat
+	// list, latest-per-name. This is where a required "workflow / job" check is found.
+	for _, ctx := range sources.rollupContexts {
+		switch ctx.Typename {
+		case "CheckRun":
+			if githubv4.String(name) == ctx.CheckRun.Name {
+				results = append(results, classifyCheckRun(ctx.CheckRun, acceptSkipped))
+			}
+		case "StatusContext":
+			if githubv4.String(name) == ctx.StatusContext.Context {
+				results = append(results, classifyStatusContext(Context{
+					Context: ctx.StatusContext.Context,
+					State:   ctx.StatusContext.State,
+				}))
+			}
+		}
+	}
+
+	// Or the required name is the name of the workflow itself, in which case the suite's conclusion
+	// is the workflow run's verdict. Suites are still read separately because a workflow whose jobs
+	// were all skipped contributes no check run to the rollup at all.
+	for _, checkSuite := range sources.suites {
 		if (checkSuite.WorkflowRun != WorkflowRun{}) && githubv4.String(name) == checkSuite.WorkflowRun.Workflow.Name {
 			conclusion := checkSuite.WorkflowRun.CheckSuite.Conclusion
 			results = append(results, checkResult{
 				outcome: classifyConclusion(conclusion, acceptSkipped),
 				verdict: verdictOf(conclusion),
 			})
-		}
-
-		// Or the name of an individual check run inside the suite, which is how
-		// a required "workflow / job" check appears.
-		for _, checkRun := range checkSuite.CheckRuns.Nodes {
-			if githubv4.String(name) == checkRun.Name {
-				results = append(results, classifyCheckRun(checkRun, acceptSkipped))
-			}
 		}
 	}
 
@@ -162,8 +195,8 @@ func collectResults(name string, edge Edge, acceptSkipped bool) []checkResult {
 // evaluateCheckName applies "nothing missing, nothing pending, nothing red" to a
 // single required check name and returns whether it is satisfied plus a line for
 // the summary.
-func evaluateCheckName(name string, edge Edge, acceptSkipped bool) (bool, string) {
-	results := collectResults(name, edge, acceptSkipped)
+func evaluateCheckName(name string, sources checkSources, acceptSkipped bool) (bool, string) {
+	results := collectResults(name, sources, acceptSkipped)
 	if len(results) == 0 {
 		return false, fmt.Sprintf("%s: NEVER RAN - no commit status, workflow run or check run carries this name", name)
 	}
@@ -204,7 +237,7 @@ func evaluateCheckName(name string, edge Edge, acceptSkipped bool) (bool, string
 // Duplicate results per name are routine, which is what made both directions of
 // that bug reachable: a merge queue builds a commit twice, and a reusable
 // workflow called by several callers reports its check once per caller.
-func evaluateSpecificChecks(edge Edge, checkNames []string, acceptSkipped bool) (bool, []string) {
+func evaluateSpecificChecks(sources checkSources, checkNames []string, acceptSkipped bool) (bool, []string) {
 	if len(checkNames) == 0 {
 		// Names were asked for but none are usable. Fail closed: an empty
 		// requirement set would make every commit vacuously promotable.
@@ -214,7 +247,7 @@ func evaluateSpecificChecks(edge Edge, checkNames []string, acceptSkipped bool) 
 	statusSuccess := true
 	summary := make([]string, 0, len(checkNames))
 	for _, name := range checkNames {
-		passed, line := evaluateCheckName(name, edge, acceptSkipped)
+		passed, line := evaluateCheckName(name, sources, acceptSkipped)
 		if !passed {
 			statusSuccess = false
 		}

--- a/github/checks_test.go
+++ b/github/checks_test.go
@@ -19,33 +19,35 @@ const (
 var dbtAppChecks = []string{checkBuildPush, checkAppTests, checkDbtTests}
 
 // completedRun builds a check run that finished with the given conclusion.
-func completedRun(name string, conclusion githubv4.CheckConclusionState) CheckRunNodes {
-	return CheckRunNodes{
-		Name:       githubv4.String(name),
-		Status:     githubv4.String(githubv4.CheckStatusStateCompleted),
-		Conclusion: githubv4.String(conclusion),
+func completedRun(name string, conclusion githubv4.CheckConclusionState) RollupContext {
+	return RollupContext{
+		Typename: "CheckRun",
+		CheckRun: RollupCheckRun{
+			Name:       githubv4.String(name),
+			Status:     githubv4.String(githubv4.CheckStatusStateCompleted),
+			Conclusion: githubv4.String(conclusion),
+		},
 	}
 }
 
 // unfinishedRun builds a check run that has not concluded yet, the way GitHub
 // reports it: a non-completed status and a null conclusion.
-func unfinishedRun(name string, status githubv4.CheckStatusState) CheckRunNodes {
-	return CheckRunNodes{
-		Name:   githubv4.String(name),
-		Status: githubv4.String(status),
+func unfinishedRun(name string, status githubv4.CheckStatusState) RollupContext {
+	return RollupContext{
+		Typename: "CheckRun",
+		CheckRun: RollupCheckRun{
+			Name:   githubv4.String(name),
+			Status: githubv4.String(status),
+		},
 	}
 }
 
-// edgeWithRuns puts every check run in its own check suite, which is how GitHub
-// reports runs that came from separate workflow runs - for instance the same
-// workflow executed once for a merge-queue run and once for the push run.
-func edgeWithRuns(runs ...CheckRunNodes) Edge {
-	suites := make([]CheckSuiteNode, 0, len(runs))
-	for _, run := range runs {
-		suites = append(suites, CheckSuiteNode{CheckRuns: CheckRuns{Nodes: []CheckRunNodes{run}}})
-	}
-
-	return Edge{Node: EdgeRootNode{CheckSuites: CheckSuites{Nodes: suites}}}
+// edgeWithRuns puts check runs where GitHub reports them for our purposes: the status-check
+// rollup, a single flat list per commit regardless of which suite each run came from.
+func edgeWithRuns(runs ...RollupContext) Edge {
+	return Edge{Node: EdgeRootNode{StatusCheckRollup: StatusCheckRollup{
+		Contexts: StatusCheckRollupContexts{Nodes: runs},
+	}}}
 }
 
 // edgeWithStatusContexts builds a commit carrying classic commit statuses rather
@@ -78,7 +80,7 @@ func TestDuplicateSuccessNoLongerMasksAFailure(t *testing.T) {
 		completedRun(checkDbtTests, githubv4.CheckConclusionStateFailure),
 	)
 
-	statusSuccess, summary := evaluateSpecificChecks(edge, dbtAppChecks, false)
+	statusSuccess, summary := evaluateSpecificChecks(sourcesFromEdge(edge), dbtAppChecks, false)
 
 	if statusSuccess {
 		t.Fatalf("a commit whose %s failed must not be promotable, summary: %v", checkDbtTests, summary)
@@ -97,7 +99,7 @@ func TestDuplicateSuccessNoLongerMasksAMissingCheck(t *testing.T) {
 		completedRun(checkAppTests, githubv4.CheckConclusionStateSuccess),
 	)
 
-	statusSuccess, summary := evaluateSpecificChecks(edge, dbtAppChecks, false)
+	statusSuccess, summary := evaluateSpecificChecks(sourcesFromEdge(edge), dbtAppChecks, false)
 
 	if statusSuccess {
 		t.Fatalf("a commit missing %s entirely must not be promotable, summary: %v", checkDbtTests, summary)
@@ -116,7 +118,7 @@ func TestExtraSuccessfulRunNoLongerBlocks(t *testing.T) {
 		completedRun(checkDbtTests, githubv4.CheckConclusionStateSuccess),
 	)
 
-	statusSuccess, summary := evaluateSpecificChecks(edge, dbtAppChecks, false)
+	statusSuccess, summary := evaluateSpecificChecks(sourcesFromEdge(edge), dbtAppChecks, false)
 
 	if !statusSuccess {
 		t.Fatalf("every required check passed, so a duplicate run must not block promotion, summary: %v", summary)
@@ -142,13 +144,13 @@ func TestSkippedPolicyIsOptIn(t *testing.T) {
 		completedRun(checkDbtTests, githubv4.CheckConclusionStateSkipped),
 	)
 
-	statusSuccess, summary := evaluateSpecificChecks(edge, dbtAppChecks, false)
+	statusSuccess, summary := evaluateSpecificChecks(sourcesFromEdge(edge), dbtAppChecks, false)
 	if statusSuccess {
 		t.Fatalf("by default a skipped required check must not satisfy the gate, summary: %v", summary)
 	}
 	assertSummaryMentions(t, summary, checkDbtTests, "did not pass")
 
-	if statusSuccess, summary := evaluateSpecificChecks(edge, dbtAppChecks, true); !statusSuccess {
+	if statusSuccess, summary := evaluateSpecificChecks(sourcesFromEdge(edge), dbtAppChecks, true); !statusSuccess {
 		t.Fatalf("with acceptSkippedChecks a skipped required check must be accepted, summary: %v", summary)
 	}
 }
@@ -168,7 +170,7 @@ func TestNeutralNeverSatisfies(t *testing.T) {
 	for _, acceptSkipped := range []bool{false, true} {
 		edge := edgeWithRuns(completedRun(hotfixSkipTests, githubv4.CheckConclusionStateNeutral))
 
-		statusSuccess, summary := evaluateSpecificChecks(edge, names, acceptSkipped)
+		statusSuccess, summary := evaluateSpecificChecks(sourcesFromEdge(edge), names, acceptSkipped)
 		if statusSuccess {
 			t.Fatalf("a neutral %s must never authorise promotion (acceptSkippedChecks=%t), summary: %v", hotfixSkipTests, acceptSkipped, summary)
 		}
@@ -176,7 +178,7 @@ func TestNeutralNeverSatisfies(t *testing.T) {
 
 	// And the authorised case still promotes.
 	edge := edgeWithRuns(completedRun(hotfixSkipTests, githubv4.CheckConclusionStateSuccess))
-	if statusSuccess, summary := evaluateSpecificChecks(edge, names, false); !statusSuccess {
+	if statusSuccess, summary := evaluateSpecificChecks(sourcesFromEdge(edge), names, false); !statusSuccess {
 		t.Fatalf("a successful %s must authorise promotion, summary: %v", hotfixSkipTests, summary)
 	}
 }
@@ -196,7 +198,7 @@ func TestSingleNameReportedTwiceStillPromotes(t *testing.T) {
 		completedRun(loadContext, githubv4.CheckConclusionStateSuccess),
 	)
 
-	statusSuccess, summary := evaluateSpecificChecks(edge, []string{loadContext}, false)
+	statusSuccess, summary := evaluateSpecificChecks(sourcesFromEdge(edge), []string{loadContext}, false)
 	if !statusSuccess {
 		t.Fatalf("four successful results for the only required name must promote, summary: %v", summary)
 	}
@@ -223,11 +225,15 @@ func TestPendingResultsBlock(t *testing.T) {
 			completedRun(checkDbtTests, githubv4.CheckConclusionStateSuccess),
 			unfinishedRun(checkDbtTests, githubv4.CheckStatusStateInProgress),
 		),
-		"workflow run with no conclusion yet": Edge{Node: EdgeRootNode{CheckSuites: CheckSuites{Nodes: []CheckSuiteNode{
-			{CheckRuns: CheckRuns{Nodes: []CheckRunNodes{completedRun(checkBuildPush, githubv4.CheckConclusionStateSuccess)}}},
-			{CheckRuns: CheckRuns{Nodes: []CheckRunNodes{completedRun(checkAppTests, githubv4.CheckConclusionStateSuccess)}}},
-			{WorkflowRun: WorkflowRun{Workflow: Workflow{Name: githubv4.String(checkDbtTests)}}},
-		}}}},
+		"workflow run with no conclusion yet": Edge{Node: EdgeRootNode{
+			StatusCheckRollup: StatusCheckRollup{Contexts: StatusCheckRollupContexts{Nodes: []RollupContext{
+				completedRun(checkBuildPush, githubv4.CheckConclusionStateSuccess),
+				completedRun(checkAppTests, githubv4.CheckConclusionStateSuccess),
+			}}},
+			CheckSuites: CheckSuites{Nodes: []CheckSuiteNode{
+				{WorkflowRun: WorkflowRun{Workflow: Workflow{Name: githubv4.String(checkDbtTests)}}},
+			}},
+		}},
 		"pending commit status": edgeWithStatusContexts(
 			Context{Context: checkBuildPush, State: githubv4.String(githubv4.StatusStateSuccess)},
 			Context{Context: checkAppTests, State: githubv4.String(githubv4.StatusStateSuccess)},
@@ -237,7 +243,7 @@ func TestPendingResultsBlock(t *testing.T) {
 
 	for name, edge := range tests {
 		t.Run(name, func(t *testing.T) {
-			statusSuccess, summary := evaluateSpecificChecks(edge, dbtAppChecks, false)
+			statusSuccess, summary := evaluateSpecificChecks(sourcesFromEdge(edge), dbtAppChecks, false)
 			if statusSuccess {
 				t.Fatalf("promoting now would pre-empt the verdict of %s, summary: %v", checkDbtTests, summary)
 			}
@@ -267,7 +273,7 @@ func TestFailingConclusionsBlock(t *testing.T) {
 				completedRun(checkDbtTests, conclusion),
 			)
 
-			statusSuccess, summary := evaluateSpecificChecks(edge, dbtAppChecks, false)
+			statusSuccess, summary := evaluateSpecificChecks(sourcesFromEdge(edge), dbtAppChecks, false)
 			if statusSuccess {
 				t.Fatalf("%s must not be treated as green, summary: %v", conclusion, summary)
 			}
@@ -293,7 +299,7 @@ func TestAllGreenPasses(t *testing.T) {
 
 	for name, edge := range tests {
 		t.Run(name, func(t *testing.T) {
-			statusSuccess, summary := evaluateSpecificChecks(edge, dbtAppChecks, false)
+			statusSuccess, summary := evaluateSpecificChecks(sourcesFromEdge(edge), dbtAppChecks, false)
 			if !statusSuccess {
 				t.Fatalf("all required checks are green, summary: %v", summary)
 			}
@@ -317,7 +323,7 @@ func TestErroredCommitStatusBlocks(t *testing.T) {
 				Context{Context: checkDbtTests, State: githubv4.String(state)},
 			)
 
-			statusSuccess, summary := evaluateSpecificChecks(edge, dbtAppChecks, false)
+			statusSuccess, summary := evaluateSpecificChecks(sourcesFromEdge(edge), dbtAppChecks, false)
 			if statusSuccess {
 				t.Fatalf("a commit status of %s must block promotion, summary: %v", state, summary)
 			}
@@ -330,11 +336,11 @@ func TestErroredCommitStatusBlocks(t *testing.T) {
 func TestWorkflowRunNameIsMatched(t *testing.T) {
 	names := []string{checkAppTests}
 
-	if statusSuccess, summary := evaluateSpecificChecks(edgeWithWorkflowRun(checkAppTests, githubv4.CheckConclusionStateSuccess), names, false); !statusSuccess {
+	if statusSuccess, summary := evaluateSpecificChecks(sourcesFromEdge(edgeWithWorkflowRun(checkAppTests, githubv4.CheckConclusionStateSuccess)), names, false); !statusSuccess {
 		t.Fatalf("a successful workflow run must satisfy its required name, summary: %v", summary)
 	}
 
-	statusSuccess, summary := evaluateSpecificChecks(edgeWithWorkflowRun(checkAppTests, githubv4.CheckConclusionStateFailure), names, false)
+	statusSuccess, summary := evaluateSpecificChecks(sourcesFromEdge(edgeWithWorkflowRun(checkAppTests, githubv4.CheckConclusionStateFailure)), names, false)
 	if statusSuccess {
 		t.Fatalf("a failed workflow run must block promotion, summary: %v", summary)
 	}
@@ -345,7 +351,7 @@ func TestWorkflowRunNameIsMatched(t *testing.T) {
 func TestMissingNameBlocks(t *testing.T) {
 	edge := edgeWithRuns(completedRun("some_other_check", githubv4.CheckConclusionStateSuccess))
 
-	statusSuccess, summary := evaluateSpecificChecks(edge, []string{checkAppTests}, false)
+	statusSuccess, summary := evaluateSpecificChecks(sourcesFromEdge(edge), []string{checkAppTests}, false)
 	if statusSuccess {
 		t.Fatalf("a required check that never ran must block promotion, summary: %v", summary)
 	}
@@ -357,7 +363,7 @@ func TestMissingNameBlocks(t *testing.T) {
 func TestNoUsableCheckNamesFailsClosed(t *testing.T) {
 	edge := edgeWithRuns(completedRun(checkAppTests, githubv4.CheckConclusionStateSuccess))
 
-	statusSuccess, summary := evaluateSpecificChecks(edge, nil, false)
+	statusSuccess, summary := evaluateSpecificChecks(sourcesFromEdge(edge), nil, false)
 	if statusSuccess {
 		t.Fatalf("an empty set of required names must not promote anything, summary: %v", summary)
 	}
@@ -417,7 +423,7 @@ func TestHydrateCommitsFallsBackToRollup(t *testing.T) {
 			// decides on this path.
 			edge := edgeWithRuns(completedRun(checkAppTests, githubv4.CheckConclusionStateFailure))
 			edge.Node.Oid = "cafebabe"
-			edge.Node.StatusCheckRollup = StatusCheckRollup{State: githubv4.String(test.rollupState)}
+			edge.Node.StatusCheckRollup.State = githubv4.String(test.rollupState)
 
 			commits := hydrateCommits(queryWithEdges(edge), "", ",", false)
 
@@ -445,7 +451,7 @@ func TestHydrateCommitsWithSpecificChecks(t *testing.T) {
 	)
 	edge.Node.Oid = "7d7d1c8b"
 	// A green rollup, to prove it is ignored once specific names are requested.
-	edge.Node.StatusCheckRollup = StatusCheckRollup{State: githubv4.String(githubv4.StatusStateSuccess)}
+	edge.Node.StatusCheckRollup.State = githubv4.String(githubv4.StatusStateSuccess)
 	names := strings.Join(dbtAppChecks, ",")
 
 	commits := hydrateCommits(queryWithEdges(edge), names, ",", false)

--- a/github/commit.go
+++ b/github/commit.go
@@ -15,4 +15,19 @@ type Commit struct {
 	AuthoredDate        time.Time
 	AuthorName          string
 	SpecificCheckPassed bool
+
+	// Everything read so far that can satisfy a required name, plus what it takes to read the
+	// rest: the required names, the skip policy, and a cursor per paginated connection.
+	sources       checkSources
+	checkNames    []string
+	acceptSkipped bool
+	suitesPage    PageInfo
+	contextsPage  PageInfo
+}
+
+// ChecksTruncated reports whether some of this commit's check data was left unread because a
+// connection had further pages. A commit that already passed needs no more data; one that did not
+// may only be failing because the deciding check sits on a page nobody fetched.
+func (c *Commit) ChecksTruncated() bool {
+	return bool(c.suitesPage.HasNextPage) || bool(c.contextsPage.HasNextPage)
 }

--- a/github/manager.go
+++ b/github/manager.go
@@ -9,6 +9,9 @@ import (
 	"golang.org/x/oauth2"
 )
 
+// maxPageSize is GitHub's per-connection limit for `first:`.
+const maxPageSize = 100
+
 // Manager represents the information necessary in Github to manage the repository
 type Manager struct {
 	Context    context.Context
@@ -32,23 +35,40 @@ func New(githubAccessToken string) *Manager {
 // When specificChecksNames is set, every name it contains must be satisfied on a
 // commit for its StatusSuccess to be true; acceptSkippedChecks additionally lets
 // a check GitHub reports as SKIPPED count as satisfied.
-func (gm *Manager) GetCommits(owner, repo, branch string, lastCommitsNumber int, specificChecksNames string, sep string, acceptSkippedChecks bool) ([]Commit, error) {
-	if lastCommitsNumber > 100 || lastCommitsNumber < 1 {
+func (gm *Manager) GetCommits(owner, repo, branch string, lastCommitsNumber int, specificChecksNames string, sep string, acceptSkippedChecks bool, contextsNumber, checkSuitesNumber int) ([]Commit, error) {
+	if lastCommitsNumber > maxPageSize || lastCommitsNumber < 1 {
 		return nil, &Error{Message: "lastCommitsNumber must be a number between 1 and 100"} // TODO maybe in future implement pagination
+	}
+	if contextsNumber > maxPageSize || contextsNumber < 1 {
+		return nil, &Error{Message: "contextsNumber must be a number between 1 and 100"}
+	}
+	if checkSuitesNumber > maxPageSize || checkSuitesNumber < 1 {
+		return nil, &Error{Message: "checkSuitesNumber must be a number between 1 and 100"}
 	}
 
 	q := &Query{}
 
 	client := gm.Client
 	err := client.Query(gm.Context, &q, map[string]interface{}{
-		"owner":         githubv4.String(owner),
-		"name":          githubv4.String(repo),
-		"branch":        githubv4.String(branch),
-		"commitsNumber": githubv4.Int(lastCommitsNumber),
-		"parentsNumber": githubv4.Int(1),
+		"owner":             githubv4.String(owner),
+		"name":              githubv4.String(repo),
+		"branch":            githubv4.String(branch),
+		"commitsNumber":     githubv4.Int(lastCommitsNumber),
+		"parentsNumber":     githubv4.Int(1),
+		"contextsNumber":    githubv4.Int(contextsNumber),
+		"checkSuitesNumber": githubv4.Int(checkSuitesNumber),
 	})
 	if nil != err {
-		return nil, err
+		// A repository with a lot of CI can make this query exceed GitHub's own execution time
+		// limit, which comes back as a 502 or 504 saying nothing about the query. The server-side
+		// work is roughly commits × (contexts + check suites), so name the knobs that shrink it.
+		return nil, &Error{
+			Message: "Can not read commits of " + branch + " because: " + err.Error() +
+				"\nIf this is a gateway timeout, the repository has more CI than one request can" +
+				" carry: lower --commits-number, or --contexts-number/--check-suites-number" +
+				" (later pages are fetched on demand, so lowering them loses nothing).",
+			PreviousError: err,
+		}
 	}
 
 	return hydrateCommits(q, specificChecksNames, sep, acceptSkippedChecks), nil
@@ -104,6 +124,65 @@ func (gm *Manager) ChangeBranchHead(owner, repo, branch, sha string, force bool)
 	return nil
 }
 
+// TopUpChecks reads the check data that did not fit in the first page and folds it into the
+// commit's verdict.
+//
+// Both statusCheckRollup.contexts and checkSuites are capped at 100 entries per page and real
+// repositories exceed that, so a commit can look unsatisfied purely because the deciding check sat
+// on a page nobody asked for. Rather than judging on a partial view, fetch the rest — but only when
+// it can still change the answer, which is why callers invoke this per commit they actually examine
+// instead of for the whole history up front. It stops as soon as every required name is satisfied.
+func (gm *Manager) TopUpChecks(owner, repo string, c *Commit) error {
+	if len(c.checkNames) == 0 {
+		return nil
+	}
+
+	for bool(c.contextsPage.HasNextPage) && !c.StatusSuccess {
+		q := &CommitContextsQuery{}
+		err := gm.Client.Query(gm.Context, q, map[string]interface{}{
+			"owner":          githubv4.String(owner),
+			"name":           githubv4.String(repo),
+			"oid":            githubv4.GitObjectID(c.SHA),
+			"contextsNumber": githubv4.Int(maxPageSize),
+			"contextsAfter":  githubv4.String(c.contextsPage.EndCursor),
+		})
+		if nil != err {
+			return &Error{Message: "Can not read further status checks for " + c.SHA + " because: " + err.Error(), PreviousError: err}
+		}
+
+		page := q.Repository.Object.Commit.StatusCheckRollup.Contexts
+		c.sources.rollupContexts = append(c.sources.rollupContexts, page.Nodes...)
+		c.contextsPage = page.PageInfo
+		c.reevaluate()
+	}
+
+	for bool(c.suitesPage.HasNextPage) && !c.StatusSuccess {
+		q := &CommitSuitesQuery{}
+		err := gm.Client.Query(gm.Context, q, map[string]interface{}{
+			"owner":             githubv4.String(owner),
+			"name":              githubv4.String(repo),
+			"oid":               githubv4.GitObjectID(c.SHA),
+			"checkSuitesNumber": githubv4.Int(maxPageSize),
+			"suitesAfter":       githubv4.String(c.suitesPage.EndCursor),
+		})
+		if nil != err {
+			return &Error{Message: "Can not read further check suites for " + c.SHA + " because: " + err.Error(), PreviousError: err}
+		}
+
+		page := q.Repository.Object.Commit.CheckSuites
+		c.sources.suites = append(c.sources.suites, page.Nodes...)
+		c.suitesPage = page.PageInfo
+		c.reevaluate()
+	}
+
+	return nil
+}
+
+// reevaluate re-runs the per-name evaluation over everything read so far.
+func (c *Commit) reevaluate() {
+	c.StatusSuccess, c.ChecksSummary = evaluateSpecificChecks(c.sources, c.checkNames, c.acceptSkipped)
+}
+
 func hydrateCommits(q *Query, specificChecksNames string, sep string, acceptSkippedChecks bool) []Commit {
 
 	var fullCommitsList []Commit
@@ -118,12 +197,16 @@ func hydrateCommits(q *Query, specificChecksNames string, sep string, acceptSkip
 
 		var statusSuccess bool
 		var checksSummary []string
+		var checkNames []string
+		var sources checkSources
 
 		if specificChecksNames == "" {
 			// No specific names were asked for, so trust GitHub's own rollup.
 			statusSuccess = edge.Node.StatusCheckRollup.State == githubv4.String(githubv4.StatusStateSuccess)
 		} else {
-			statusSuccess, checksSummary = evaluateSpecificChecks(edge, splitCheckNames(specificChecksNames, sep), acceptSkippedChecks)
+			checkNames = splitCheckNames(specificChecksNames, sep)
+			sources = sourcesFromEdge(edge)
+			statusSuccess, checksSummary = evaluateSpecificChecks(sources, checkNames, acceptSkippedChecks)
 		}
 
 		fullCommitsList = append(fullCommitsList, Commit{
@@ -134,6 +217,11 @@ func hydrateCommits(q *Query, specificChecksNames string, sep string, acceptSkip
 			ChecksSummary: checksSummary,
 			AuthoredDate:  edge.Node.AuthoredDate.Time,
 			AuthorName:    string(edge.Node.Author.Name),
+			sources:       sources,
+			checkNames:    checkNames,
+			acceptSkipped: acceptSkippedChecks,
+			suitesPage:    edge.Node.CheckSuites.PageInfo,
+			contextsPage:  edge.Node.StatusCheckRollup.Contexts.PageInfo,
 		})
 	}
 

--- a/github/pagination_test.go
+++ b/github/pagination_test.go
@@ -1,0 +1,162 @@
+package github
+
+import (
+	"testing"
+
+	"github.com/shurcooL/githubv4"
+)
+
+// GitHub caps checkSuites and statusCheckRollup.contexts at 100 entries per page, and repositories
+// with a lot of CI exceed that, so a commit can look unsatisfied only because the deciding check sat
+// on a page nobody asked for. These cover the two halves of the contract that prevents a verdict
+// being reached on a partial view: noticing that a page is missing, and folding a fetched page in.
+
+func edgeWithMorePages(edge Edge, contextsNext, suitesNext bool) Edge {
+	edge.Node.StatusCheckRollup.Contexts.PageInfo = PageInfo{
+		HasNextPage: githubv4.Boolean(contextsNext),
+		EndCursor:   "contexts-cursor",
+	}
+	edge.Node.CheckSuites.PageInfo = PageInfo{
+		HasNextPage: githubv4.Boolean(suitesNext),
+		EndCursor:   "suites-cursor",
+	}
+
+	return edge
+}
+
+func TestChecksTruncatedTracksBothConnections(t *testing.T) {
+	tests := map[string]struct {
+		contextsNext, suitesNext bool
+		expected                 bool
+	}{
+		"both connections complete": {false, false, false},
+		"more rollup contexts":      {true, false, true},
+		"more check suites":         {false, true, true},
+		"more of both":              {true, true, true},
+	}
+
+	for name, test := range tests {
+		test := test
+		t.Run(name, func(t *testing.T) {
+			edge := edgeWithMorePages(
+				edgeWithRuns(completedRun(checkAppTests, githubv4.CheckConclusionStateSuccess)),
+				test.contextsNext, test.suitesNext,
+			)
+
+			commits := hydrateCommits(queryWithEdges(edge), checkAppTests, ",", false)
+			if len(commits) != 1 {
+				t.Fatalf("expected exactly one hydrated commit, got %d", len(commits))
+			}
+			if got := commits[0].ChecksTruncated(); got != test.expected {
+				t.Errorf("ChecksTruncated() = %t, want %t", got, test.expected)
+			}
+		})
+	}
+}
+
+// A commit with no required names never needs more data, whatever the cursors say: the rollup-state
+// path does not read these connections at all.
+func TestChecksTruncatedIgnoredWithoutRequiredNames(t *testing.T) {
+	edge := edgeWithMorePages(edgeWithRuns(), true, true)
+
+	commits := hydrateCommits(queryWithEdges(edge), "", ",", false)
+	if len(commits) != 1 {
+		t.Fatalf("expected exactly one hydrated commit, got %d", len(commits))
+	}
+	if len(commits[0].checkNames) != 0 {
+		t.Fatalf("expected no required names, got %v", commits[0].checkNames)
+	}
+}
+
+// The half of TopUpChecks that does not touch the network: a required name found only on a later
+// page must flip the commit once that page is folded in.
+func TestLaterPageSatisfiesARequiredName(t *testing.T) {
+	edge := edgeWithMorePages(
+		edgeWithRuns(completedRun(checkAppTests, githubv4.CheckConclusionStateSuccess)),
+		true, false,
+	)
+
+	commits := hydrateCommits(queryWithEdges(edge), checkAppTests+","+checkDbtTests, ",", false)
+	if len(commits) != 1 {
+		t.Fatalf("expected exactly one hydrated commit, got %d", len(commits))
+	}
+	commit := &commits[0]
+
+	if commit.StatusSuccess {
+		t.Errorf("StatusSuccess = true on the first page alone, want false: %q has not been seen yet", checkDbtTests)
+	}
+	if !commit.ChecksTruncated() {
+		t.Fatalf("ChecksTruncated() = false, want true: the rollup reported a further page")
+	}
+
+	// What TopUpChecks does with the page it fetches.
+	commit.sources.rollupContexts = append(commit.sources.rollupContexts,
+		completedRun(checkDbtTests, githubv4.CheckConclusionStateSuccess))
+	commit.reevaluate()
+
+	if !commit.StatusSuccess {
+		t.Errorf("StatusSuccess = false after the second page, want true: %v", commit.ChecksSummary)
+	}
+}
+
+// A later page must be able to settle a name in the other direction too, so that paging cannot turn
+// a red check into a promotion.
+func TestLaterPageCanRevealAFailure(t *testing.T) {
+	edge := edgeWithMorePages(edgeWithRuns(), true, false)
+
+	commits := hydrateCommits(queryWithEdges(edge), checkDbtTests, ",", false)
+	commit := &commits[0]
+
+	commit.sources.rollupContexts = append(commit.sources.rollupContexts,
+		completedRun(checkDbtTests, githubv4.CheckConclusionStateFailure))
+	commit.reevaluate()
+
+	if commit.StatusSuccess {
+		t.Errorf("StatusSuccess = true, want false: the later page carried a failure")
+	}
+}
+
+// A workflow-name requirement is only satisfiable from the check-suites connection, which is the
+// reason that connection is still selected separately from the rollup.
+func TestLaterSuitePageSatisfiesAWorkflowName(t *testing.T) {
+	edge := edgeWithMorePages(edgeWithRuns(), false, true)
+
+	commits := hydrateCommits(queryWithEdges(edge), checkAppTests, ",", false)
+	commit := &commits[0]
+
+	if commit.StatusSuccess {
+		t.Fatalf("StatusSuccess = true before any suite was read, want false")
+	}
+
+	commit.sources.suites = append(commit.sources.suites, CheckSuiteNode{WorkflowRun: WorkflowRun{
+		Workflow:   Workflow{Name: githubv4.String(checkAppTests)},
+		CheckSuite: CheckSuite{Conclusion: githubv4.String(githubv4.CheckConclusionStateSuccess)},
+	}})
+	commit.reevaluate()
+
+	if !commit.StatusSuccess {
+		t.Errorf("StatusSuccess = false after the later suite page, want true: %v", commit.ChecksSummary)
+	}
+}
+
+func TestGetCommitsRejectsOutOfRangePageSizes(t *testing.T) {
+	gm := New("token")
+
+	tests := map[string]struct {
+		contexts, suites int
+	}{
+		"contexts too large": {101, 50},
+		"contexts too small": {0, 50},
+		"suites too large":   {50, 101},
+		"suites too small":   {50, 0},
+	}
+
+	for name, test := range tests {
+		test := test
+		t.Run(name, func(t *testing.T) {
+			if _, err := gm.GetCommits("o", "r", "b", 25, "", ",", false, test.contexts, test.suites); err == nil {
+				t.Errorf("expected an error for contexts=%d suites=%d, got none", test.contexts, test.suites)
+			}
+		})
+	}
+}

--- a/github/types.go
+++ b/github/types.go
@@ -2,19 +2,6 @@ package github
 
 import "github.com/shurcooL/githubv4"
 
-// CheckRunNodes represents the checkRun status of the Nodes
-type CheckRunNodes struct {
-	Name       githubv4.String
-	Status     githubv4.String
-	Title      githubv4.String
-	Conclusion githubv4.String
-}
-
-// CheckRuns represents the check run of an array of Nodes
-type CheckRuns struct {
-	Nodes []CheckRunNodes
-}
-
 // Workflow represents the information of the Github Workflow
 type Workflow struct {
 	Name githubv4.String
@@ -31,15 +18,28 @@ type WorkflowRun struct {
 	CheckSuite CheckSuite
 }
 
-// CheckSuiteNode represents the information about the check suite information of the Node
+// CheckSuiteNode represents the information about the check suite information of the Node.
+//
+// It deliberately does not select the nested checkRuns connection. Check runs are read from
+// statusCheckRollup.contexts instead: nesting checkRuns under checkSuites multiplied the query's
+// node count by suites × runs for every commit, and made whether a run was visible at all depend on
+// where its suite happened to sort. This selection is only needed for a required name that is the
+// name of a *workflow* rather than of an individual run.
 type CheckSuiteNode struct {
 	WorkflowRun WorkflowRun
-	CheckRuns   CheckRuns `graphql:"checkRuns(first: 25)"`
 }
 
 // CheckSuites represents the information about the check suite of a slice of Nodes
 type CheckSuites struct {
-	Nodes []CheckSuiteNode
+	TotalCount githubv4.Int
+	PageInfo   PageInfo
+	Nodes      []CheckSuiteNode
+}
+
+// PageInfo carries a connection's cursor so the pages that did not fit can be fetched on demand.
+type PageInfo struct {
+	HasNextPage githubv4.Boolean
+	EndCursor   githubv4.String
 }
 
 // Context represents the information about the Context
@@ -48,7 +48,10 @@ type Context struct {
 	State   githubv4.String
 }
 
-// NodeStatus represents the information about a slice of Contexts
+// NodeStatus represents the information about a slice of Contexts.
+//
+// Commit.status.contexts is a plain list rather than a connection, so this is always the complete
+// set of classic commit statuses — there is nothing to paginate.
 type NodeStatus struct {
 	Contexts []Context
 }
@@ -64,15 +67,43 @@ type EdgeParent struct {
 	Node EdgeNode
 }
 
-// StatusCheckRollupContexts represents the information about the status check of roullup contexts
+// RollupStatusContext is the StatusContext member of the statusCheckRollup contexts union: a
+// classic commit status, as reported through the rollup.
+type RollupStatusContext struct {
+	Context githubv4.String
+	State   githubv4.String
+}
+
+// RollupCheckRun is the CheckRun member of the statusCheckRollup contexts union.
+type RollupCheckRun struct {
+	Name       githubv4.String
+	Status     githubv4.String
+	Conclusion githubv4.String
+}
+
+// RollupContext is one entry of statusCheckRollup.contexts, a union of StatusContext and CheckRun.
+// Typename says which member is populated.
+type RollupContext struct {
+	Typename      githubv4.String     `graphql:"__typename"`
+	StatusContext RollupStatusContext `graphql:"... on StatusContext"`
+	CheckRun      RollupCheckRun      `graphql:"... on CheckRun"`
+}
+
+// StatusCheckRollupContexts represents the information about the status check of rollup contexts.
+//
+// This is where check runs are read from. GitHub returns the latest run per check name here, so
+// re-runs of the same check arrive as one entry rather than one per attempt, and the list is flat
+// rather than grouped by suite.
 type StatusCheckRollupContexts struct {
 	TotalCount githubv4.Int
+	PageInfo   PageInfo
+	Nodes      []RollupContext
 }
 
 // StatusCheckRollup represents the information about the status check of rollup
 type StatusCheckRollup struct {
 	State    githubv4.String
-	Contexts StatusCheckRollupContexts `graphql:"contexts(first: $parentsNumber)"`
+	Contexts StatusCheckRollupContexts `graphql:"contexts(first: $contextsNumber)"`
 }
 
 // Author represents the information about the commit author
@@ -93,7 +124,7 @@ type EdgeRootNode struct {
 	AuthoredDate      githubv4.DateTime
 	Author            Author
 	StatusCheckRollup StatusCheckRollup
-	CheckSuites       CheckSuites `graphql:"checkSuites(first: 20)"`
+	CheckSuites       CheckSuites `graphql:"checkSuites(first: $checkSuitesNumber)"`
 	Status            NodeStatus
 }
 
@@ -130,4 +161,28 @@ type Repository struct {
 // Query represents the information obtained in a Github Query
 type Query struct {
 	Repository Repository `graphql:"repository(owner: $owner, name: $name)"`
+}
+
+// CommitContextsQuery fetches one further page of a single commit's status-check rollup contexts.
+type CommitContextsQuery struct {
+	Repository struct {
+		Object struct {
+			Commit struct {
+				StatusCheckRollup struct {
+					Contexts StatusCheckRollupContexts `graphql:"contexts(first: $contextsNumber, after: $contextsAfter)"`
+				}
+			} `graphql:"... on Commit"`
+		} `graphql:"object(oid: $oid)"`
+	} `graphql:"repository(owner: $owner, name: $name)"`
+}
+
+// CommitSuitesQuery fetches one further page of a single commit's check suites.
+type CommitSuitesQuery struct {
+	Repository struct {
+		Object struct {
+			Commit struct {
+				CheckSuites CheckSuites `graphql:"checkSuites(first: $checkSuitesNumber, after: $suitesAfter)"`
+			} `graphql:"... on Commit"`
+		} `graphql:"object(oid: $oid)"`
+	} `graphql:"repository(owner: $owner, name: $name)"`
 }

--- a/manager/flow-manager.go
+++ b/manager/flow-manager.go
@@ -18,20 +18,20 @@ func checkGithubToken(githubToken string) error {
 }
 
 // Manage will do the necessary actions to move the head from one branch to another
-func Manage(githubToken, owner, repo, sourceBranch, destinationBranch, expression string, specificChecksNames string, sep string, acceptSkippedChecks bool, lastCommitsNumber int, force, dryRun bool) ([]EvaluationResult, error) {
+func Manage(githubToken, owner, repo, sourceBranch, destinationBranch, expression string, specificChecksNames string, sep string, acceptSkippedChecks bool, contextsNumber, checkSuitesNumber int, lastCommitsNumber int, force, dryRun bool) ([]EvaluationResult, error) {
 	err := checkGithubToken(githubToken)
 	if err != nil {
 		return nil, err
 	}
 	parsedExpression := expr.MustParse(expression)
 	gm := github.New(githubToken)
-	commits, err := gm.GetCommits(owner, repo, sourceBranch, lastCommitsNumber, specificChecksNames, sep, acceptSkippedChecks)
+	commits, err := gm.GetCommits(owner, repo, sourceBranch, lastCommitsNumber, specificChecksNames, sep, acceptSkippedChecks, contextsNumber, checkSuitesNumber)
 	if nil != err {
 		return nil, err
 	}
 	firstParentCommits := github.PickFirstParentCommits(commits)
 
-	destinationCommits, err := gm.GetCommits(owner, repo, destinationBranch, 1, specificChecksNames, sep, acceptSkippedChecks)
+	destinationCommits, err := gm.GetCommits(owner, repo, destinationBranch, 1, specificChecksNames, sep, acceptSkippedChecks, contextsNumber, checkSuitesNumber)
 	if nil != err {
 		return nil, err
 	}
@@ -43,6 +43,16 @@ func Manage(githubToken, owner, repo, sourceBranch, destinationBranch, expressio
 		if destinationCommits[0].SHA == commit.SHA {
 			fmt.Println("COMMIT ID: " + commit.SHA + " IS ALREADY IN " + destinationBranch + " branch. EXITING THE PROCESS WITHOUT ANY ACTION.")
 			return evaluationResultList, nil
+		}
+
+		// The first page of check data may not have covered every check on this commit. Reading the
+		// rest is only worth a request when the commit has not already passed, and only for the
+		// commits actually examined — which is why it happens here rather than in GetCommits: this
+		// loop stops at the first commit that passes, so the usual case costs nothing extra.
+		if !commit.StatusSuccess && commit.ChecksTruncated() {
+			if err := gm.TopUpChecks(owner, repo, &commit); err != nil {
+				return nil, err
+			}
 		}
 
 		evalContext := datasource.NewContextSimpleNative(map[string]interface{}{

--- a/testdata/baseline/README.md
+++ b/testdata/baseline/README.md
@@ -1,0 +1,42 @@
+# Promotion-verdict baseline
+
+A regression net for changes to check evaluation. It records, for a set of real repositories, the
+verdict this binary reaches for every commit it examines — then lets you re-record after a change
+and diff.
+
+It exists because the failure mode in this area is silent. When a required check is not found, or is
+found more times than expected, the commit simply fails evaluation and the CLI still exits 0. Unit
+tests cover the evaluation logic (`github/manager_test.go`), but they cannot catch a regression in
+the GraphQL query itself — a check that is no longer fetched looks exactly like a check that failed.
+Only running against real repositories catches that.
+
+## Usage
+
+```sh
+cp consumers.tsv.example consumers.tsv   # then edit: your repos, your real status_check_names
+./record.sh /path/to/known-good-gfm  before/     # e.g. a binary from the latest release
+# ... make your change, build a new binary ...
+./record.sh ./gfm-new                 after/
+diff -ru before/ after/
+```
+
+Every run is `--dry-run` and uses an expression that can never be true, so no branch head is ever
+moved and no commit is ever promoted.
+
+Read `consumers.tsv.example` before filling in `consumers.tsv` — the choice of `destination` is the
+one non-obvious part, and getting it wrong silently produces empty recordings.
+
+## Reading a diff
+
+The column that matters is `IS_STATUS_SUCCESS`: it is computed purely from the requested
+`status_check_names`, so it isolates check evaluation from everything else.
+
+A diff is not automatically a regression. These recordings read live CI state, so a repository whose
+CI moved between the two runs will differ for unrelated reasons — that is what the SHAs in each file
+are for. If a repository moved, re-record it; do not reason about the diff. What matters is that
+every remaining difference is one you intended and can name.
+
+## Why this is not committed
+
+`consumers.tsv` and the output directories are gitignored. Recorded output embeds commit messages,
+author names and branch names; for private repositories none of that belongs in a public repo.

--- a/testdata/baseline/consumers.tsv.example
+++ b/testdata/baseline/consumers.tsv.example
@@ -1,0 +1,23 @@
+# Copy to consumers.tsv (gitignored) and fill in with your own repos.
+#
+# One row per repository whose promotion verdict you want to pin, tab-separated:
+#
+#   repo<TAB>source<TAB>destination<TAB>status_check_names
+#
+# `status_check_names` should be exactly what you pass to github-flow-manager in production,
+# so the baseline reflects real configuration rather than a guess.
+#
+# `destination` should NOT be your production destination branch. If source and destination
+# already point at the same commit — the normal state right after a promotion — GFM prints
+# "IS ALREADY IN <branch> branch" and exits before evaluating a single check, so the recording
+# captures nothing. Pick instead any branch that is *not* an ancestor of the source branch
+# (an old feature branch works): GFM then evaluates the whole --commits-number window. Combined
+# with the unsatisfiable expression record.sh uses, nothing is ever promoted.
+#
+# Verify a row is useful by checking its output has as many commit rows as --commits-number.
+#
+# consumers.tsv is gitignored on purpose: recorded output embeds commit messages, author names
+# and branch names, which for private repositories must not be committed to a public repo.
+
+example-app	develop	some-old-feature-branch	Continuous Integration
+other-app	develop	some-old-feature-branch	unit-tests,publish-image / publish-image-example

--- a/testdata/baseline/record.sh
+++ b/testdata/baseline/record.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Record the check-evaluation verdict this binary produces for every real consumer repo.
+#
+# The characterization target is the IS_STATUS_SUCCESS column: it is computed purely by
+# hydrateCommits from the requested status_check_names, independent of the expression. So we run
+# with an expression that can never be true, which means:
+#   - no commit ever "passes", so the promotion branch is never taken (belt to --dry-run's braces)
+#   - the loop is never cut short by a success, so every examined commit appears in the table
+# Combined with the non-ancestor probe destinations in consumers.tsv, this prints a full table of
+# per-commit verdicts, which is exactly what must not change across a refactor.
+#
+#   ./record.sh <path-to-github-flow-manager-binary> <output-dir>
+#
+# Compare a refactor against the recorded baseline:
+#   ./record.sh ./gfm-new /tmp/out-new && diff -ru testdata/baseline/v1.1.10 /tmp/out-new
+#
+# The verdict depends on live GitHub CI state, so a repo whose CI moved between the two runs will
+# differ for reasons unrelated to the code. Each output records the SHAs it saw so drift is visible
+# rather than silent — re-record a moved repo, don't explain the diff away.
+set -uo pipefail
+
+BIN="${1:?usage: record.sh <binary> <output-dir>}"
+OUT="${2:?usage: record.sh <binary> <output-dir>}"
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COMMITS="${COMMITS:-25}" # match whatever your promote workflow passes as --commits-number
+
+# Deliberately unsatisfiable: see header.
+EXPRESSION='Message contains "___gfm_baseline_never_match___"'
+
+: "${GITHUB_TOKEN:="$(gh auth token 2>/dev/null)"}"
+if [ -z "$GITHUB_TOKEN" ]; then
+  echo "GITHUB_TOKEN unset and 'gh auth token' produced nothing" >&2
+  exit 1
+fi
+export GITHUB_TOKEN
+
+mkdir -p "$OUT"
+
+while IFS=$'\t' read -r repo source dest checks; do
+  case "$repo" in '' | '#'*) continue ;; esac
+
+  echo "recording $repo ..." >&2
+  {
+    echo "# repo=$repo source=$source destination=$dest commits=$COMMITS"
+    echo "# expression=$EXPRESSION"
+    echo "# status_check_names=$checks"
+    echo "#"
+    "$BIN" DocPlanner "$repo" "$source" "$dest" "$EXPRESSION" "$checks" \
+      -c "$COMMITS" --dry-run --verbose 2>&1
+    echo "# exit=$?"
+  } >"$OUT/$repo.txt"
+done <"$HERE/consumers.tsv"
+
+echo "wrote $(find "$OUT" -name '*.txt' | wc -l | tr -d ' ') files to $OUT" >&2


### PR DESCRIPTION
**Stacked on #37 — review and merge that one first.** The base of this PR is `fix/per-name-required-check-coverage`, so the diff here shows only the query layer. I'll retarget it to `master` once #37 lands.

This is the follow-up #37 asks for in its "Known limitation, deliberately not fixed here" section. #37 fixes how results are *counted*; this fixes what gets *fetched*. Identifiers are generic below — this repository is public.

## What was wrong

`checkSuites(first: 20)` with a nested `checkRuns(first: 25)`, both hardcoded:

- a required check could sit outside that window and never be fetched, so "not satisfied" partly depended on where a suite happened to sort
- because the connections were nested, the node count was `commits × suites × runs`

Measured: **27** check suites on a merge commit of a large monorepo, and **105–134** on the heaviest consumer — already past the 100-per-connection maximum, so widening alone cannot fix it even in principle.

## What changed

Check runs come from `statusCheckRollup.contexts`, which is flat and returns the latest run per name — suite ordering stops deciding visibility, and re-runs arrive as one entry instead of one per attempt.

`checkSuites` is still selected, minus its nested runs. I checked whether the rollup could replace it outright (`CheckRun.checkSuite.workflowRun.workflow.name` costs 0 extra nodes, so it looked free): it cannot. On the 134-suite commit the rollup yields 4 of the 6 SUCCESS workflow names, the other two having been de-duplicated away by name collisions. A required name can also be a workflow whose jobs were all skipped, which contributes no run to the rollup at all.

**It costs less than before, not more** — which is where #33 and #35 got stuck:

| query shape | commits | nodeCount | charged cost |
|---|---|---|---|
| before | 25 | 13,075 | **6** |
| before | 100 | 52,300 | **23** |
| #33's shape (`100 × 100`) | 25 | 252,575 | **26** |
| #33's shape (`100 × 100`) | 100 | — | **`MAX_NODE_LIMIT_EXCEEDED`** |
| this PR | 25 | 5,050 | **1** |
| this PR | 100 | 20,200 | **3** |

Two corrections to the record while we're here: #35's "~20× / 2,526 points" was `nodeCount / 100`, not the cost GitHub charges — the real increase was 6 → 26. And what should have blocked #33 outright is the last row: at the CLI's own default `-c 100` that shape is rejected before it executes. It only ever worked because the reusable workflow passes `-c 25`.

## Paging past 100

The caps are now `--contexts-number` and `--check-suites-number`, and the remainder is fetched by `TopUpChecks`. That runs from the evaluation loop rather than from hydration, because the loop already stops at the first commit that passes: **no extra request in the usual case**, at most one page-set per commit actually examined, and no commit judged on a partial view.

Proven by asymmetry rather than by assertion: at `--check-suites-number 5` the first page of that commit contains no workflow runs *at all*, yet a name that can only resolve via a workflow still comes back ✔.

**They default to 50, not 100, because rate limit is not the only ceiling.** On the heaviest consumer a 100/100 first page makes GitHub exceed its own query execution time and return `504`; at `-c 50` or above it times out at *every* page size I tried, including 25/25 — and so does the pre-change query (`502`). So the limit is pre-existing rather than introduced, and both binaries succeed at `-c 25`, which is what the reusable workflow passes. `GetCommits` now names the knobs to turn when it happens.

## Effect on #37's code

Evaluation reads from a different place, so `collectResults` takes the accumulated sources rather than one query edge, via a shared `sourcesFromEdge` adapter. **The 42 existing cases are otherwise untouched and all still pass.** Two of them set `StatusCheckRollup` wholesale, which now discards the runs, so they set `State` only — same intent, and arguably a sharper test since the red run it plants is no longer thrown away.

14 new cases cover truncation detection, a later page satisfying a name, a later page revealing a *failure* (so paging can't turn red into a promotion), a later suite page satisfying a workflow name, and page-size validation.

## Verification

- `go build`, `go vet`, `go test ./...` (56 cases), `gofmt -l`, `golangci-lint` v1.44.2 as CI, `pre-commit run -a` — all clean.
- **Recorded the promotion verdict for all 11 consumer repositories against #37's branch and against this one: identical across every commit examined.** This changes how checks are fetched and nothing about how they are judged — which is the property I actually wanted from it, given #37 is the change that intentionally moves verdicts.

`testdata/baseline/` is the harness for that comparison. Its repository list and recordings are gitignored: recorded output embeds commit messages, author names and branch names, and this repo is public.

## Not in scope

Nothing here touches the acceptance rule — `SUCCESS` only, `NEUTRAL` never, `SKIPPED` per #37's flag. A skipped run still arrives with conclusion `SKIPPED` when read from the rollup, so that policy is unaffected.
